### PR TITLE
PD: always check the timeout on receiving packets

### DIFF
--- a/src/osdp_pd.c
+++ b/src/osdp_pd.c
@@ -865,9 +865,6 @@ static void osdp_pd_update(struct osdp_pd *pd)
 	switch (pd->state) {
 	case OSDP_PD_STATE_IDLE:
 		ret = pd_receve_packet(pd);
-		if (ret == 1) {
-			break;
-		}
 		if (ret == -1 || (pd->rx_buf_len > 0 &&
 		    osdp_millis_since(pd->tstamp) > OSDP_RESP_TOUT_MS)) {
 			/**
@@ -876,6 +873,9 @@ static void osdp_pd_update(struct osdp_pd *pd)
 			 */
 			LOG_ERR(TAG "receive errors/timeout");
 			pd->state = OSDP_PD_STATE_ERR;
+			break;
+		}
+		if (ret == 1) {
 			break;
 		}
 		if (ret == 0) {


### PR DESCRIPTION
without this change pd will hang if it receives too many bytes.
it might also hang if the LEN_LSB or LEN_MSB is corrupted.

Signed-off-by: Johan Carlsson <johan.carlsson@teenage.engineering>