### PR TITLE
python: change len from int to the correct type of Py_ssize_t.

### DIFF
--- a/python/pyosdp_utils.c
+++ b/python/pyosdp_utils.c
@@ -137,7 +137,7 @@ int pyosdp_dict_get_bytes(PyObject *dict, const char *key, uint8_t **data, int *
 {
 	PyObject *obj;
 	uint8_t *buf;
-	int len;
+	Py_ssize_t len;
 
 	obj = PyDict_GetItemString(dict, key);
 	if (obj == NULL) {


### PR DESCRIPTION
This solves the crash i've been seeing. What seems to happen
is that PyArg_Parse writes to a 64-bit type and we input a
32-bit, so the buf pointer have its lowest 4 bytes corrupted.

Signed-off-by: Johan Carlsson <johan.carlsson@teenage.engineering>