### PR TITLE
do not flush rx queue when skipping commands.

### DIFF
--- a/src/osdp_cp.c
+++ b/src/osdp_cp.c
@@ -693,9 +693,6 @@ static int cp_process_reply(struct osdp_pd *pd)
 	} else if (ret == OSDP_ERR_PKT_SKIP) {
 		/* soft fail - discard this message */
 		pd->rx_buf_len = 0;
-		if (pd->channel.flush) {
-			pd->channel.flush(pd->channel.data);
-		}
 		return OSDP_CP_ERR_NO_DATA;
 	}
 	pd->rx_buf_len = ret;

--- a/src/osdp_pd.c
+++ b/src/osdp_pd.c
@@ -926,9 +926,6 @@ static int pd_receve_packet(struct osdp_pd *pd)
 	} else if (ret == OSDP_ERR_PKT_SKIP) {
 		/* soft fail - discard this message */
 		pd->rx_buf_len = 0;
-		if (pd->channel.flush) {
-			pd->channel.flush(pd->channel.data);
-		}
 		return 1;
 	}
 	pd->rx_buf_len = ret;


### PR DESCRIPTION
when skipping commands addressed to other nodes the rx queue
should not be flushed. The complete command is already received and
flushing the rx queue only risks removing bytes in the next command.