### PR TITLE
Call to osdp_dump was using incorrect length

### DIFF
--- a/src/osdp_cp.c
+++ b/src/osdp_cp.c
@@ -629,7 +629,7 @@ static int cp_send_command(struct osdp_pd *pd)
 
 	if (IS_ENABLED(CONFIG_OSDP_PACKET_TRACE)) {
 		if (pd->cmd_id != CMD_POLL) {
-			osdp_dump(pd->rx_buf, pd->rx_buf_len,
+			osdp_dump(pd->rx_buf, len,
 				  "OSDP: PD[%d]: Sent", pd->offset);
 		}
 	}


### PR DESCRIPTION
`pd->rx_buf_len` is 0 both when `pd->channel.send()` is called and here at the call to `osdp_dump()`