### PR TITLE
pd: Fix device capabilities report

### DIFF
--- a/src/osdp_pd.c
+++ b/src/osdp_pd.c
@@ -623,7 +623,7 @@ static int pd_build_reply(struct osdp_pd *pd, uint8_t *buf, int max_len)
 	case REPLY_PDCAP:
 		ASSERT_BUF_LEN(REPLY_PDCAP_LEN);
 		buf[len++] = pd->reply_id;
-		for (i = 0; i < OSDP_PD_CAP_SENTINEL; i++) {
+		for (i = 1; i < OSDP_PD_CAP_SENTINEL; i++) {
 			if (pd->cap[i].function_code != i) {
 				continue;
 			}


### PR DESCRIPTION
Do not check or send the first entry in the pd->cp[] device capability
table which is for function code 0 which is not a defined function code.