### PR TITLE
pd: Use better NAK error code when rejecting a command due to SC inactive

### DIFF
--- a/src/osdp_common.h
+++ b/src/osdp_common.h
@@ -183,7 +183,7 @@ enum osdp_pd_nak_code_e {
 	 */
 	OSDP_PD_NAK_CMD_UNKNOWN,
 	/**
-	 * @brief This PD does not support the security block that was received
+	 * @brief Sequence number error
 	 */
 	OSDP_PD_NAK_SEQ_NUM,
 	/**

--- a/src/osdp_pd.c
+++ b/src/osdp_pd.c
@@ -246,7 +246,7 @@ static int pd_decode_command(struct osdp_pd *pd, uint8_t *buf, int len)
 			LOG_ERR("CMD(%02x) not allowed due to ENFORCE_SECURE",
 				pd->cmd_id);
 			pd->reply_id = REPLY_NAK;
-			pd->ephemeral_data[0] = OSDP_PD_NAK_RECORD;
+			pd->ephemeral_data[0] = OSDP_PD_NAK_SC_COND;
 			return OSDP_PD_ERR_REPLY;
 		}
 	}


### PR DESCRIPTION
Also fix the description comment for OSDP_PD_NAK_SEQ_NUM.
