### PR TITLE
osdp decrypt data : Tolerate null length data

### DIFF
--- a/src/osdp_sc.c
+++ b/src/osdp_sc.c
@@ -140,6 +140,10 @@ int osdp_decrypt_data(struct osdp_pd *pd, int is_cmd, uint8_t *data, int length)
 	int i;
 	uint8_t iv[16];
 
+	if (length == 0) {
+		return 0;
+	}
+
 	if (length % 16 != 0) {
 		return -1;
 	}


### PR DESCRIPTION
Hello,
Thanks for this good library ! 
I think i found a small bug when the function osdp_decrypt_data is call with null length, the function return -1.