### PR TITLE
libosdp: Added opaque argument to command_complete_callback

### DIFF
--- a/include/osdp.h
+++ b/include/osdp.h
@@ -710,9 +710,11 @@ typedef int (*cp_event_callback_t)(void *arg, int pd, struct osdp_event *ev);
  * been registered with `osdp_set_command_complete_callback()` this method is
  * invoked after a command has been processed successfully in CP and PD sides.
  *
+ * @param arg pointer that will was passed to the arg param of
+ * `osdp_set_command_complete_callback`.
  * @param id OSDP command ID (Note: this is not `enum osdp_cmd_e`)
  */
-typedef void (*osdp_command_complete_callback_t)(int id);
+typedef void (*osdp_command_complete_callback_t)(void *arg, int id);
 
 /* ------------------------------- */
 /*            PD Methods           */
@@ -1000,9 +1002,11 @@ void osdp_get_sc_status_mask(osdp_t *ctx, uint8_t *bitmask);
  *
  * @param ctx OSDP context
  * @param cb Callback to be invoked when a command is completed.
+ * @param arg A pointer that will be passed as the first argument of `cb`
  */
 void osdp_set_command_complete_callback(osdp_t *ctx,
-					osdp_command_complete_callback_t cb);
+					osdp_command_complete_callback_t cb,
+					void *arg);
 
 /**
  * @brief OSDP File operations struct that needs to be filled by the CP/PD

--- a/include/osdp.hpp
+++ b/include/osdp.hpp
@@ -41,9 +41,9 @@ public:
 		osdp_get_sc_status_mask(_ctx, bitmask);
 	}
 
-	void set_command_complete_callback(osdp_command_complete_callback_t cb)
+	void set_command_complete_callback(osdp_command_complete_callback_t cb, void *arg)
 	{
-		osdp_set_command_complete_callback(_ctx, cb);
+		osdp_set_command_complete_callback(_ctx, cb, arg);
 	}
 
 	int file_register_ops(int pd, struct osdp_file_ops *ops)

--- a/src/osdp_common.c
+++ b/src/osdp_common.c
@@ -270,9 +270,11 @@ void osdp_get_status_mask(osdp_t *ctx, uint8_t *bitmask)
 
 OSDP_EXPORT
 void osdp_set_command_complete_callback(osdp_t *ctx,
-					osdp_command_complete_callback_t cb)
+					osdp_command_complete_callback_t cb,
+					void *arg)
 {
 	input_check(ctx);
 
 	TO_OSDP(ctx)->command_complete_callback = cb;
+	TO_OSDP(ctx)->command_complete_callback_arg = arg;
 }

--- a/src/osdp_common.h
+++ b/src/osdp_common.h
@@ -344,7 +344,11 @@ struct osdp {
 	int *channel_lock;     /* array of length NUM_PD() to lock a channel */
 	uint8_t sc_master_key[16]; /* Secure Channel master key (deprecated) */
 
-	/* OSDP defined command complete callback subscription */
+	/**
+	 * OSDP defined command complete callback subscription with opaque arg 
+	 * pointer as passed by app
+	 **/
+	void *command_complete_callback_arg;
 	osdp_command_complete_callback_t command_complete_callback;
 
 	/* CP event callback to app with opaque arg pointer as passed by app */

--- a/src/osdp_cp.c
+++ b/src/osdp_cp.c
@@ -837,7 +837,8 @@ static int cp_phy_state_update(struct osdp_pd *pd)
 		rc = cp_process_reply(pd);
 		if (rc == OSDP_CP_ERR_NONE) {
 			if (ctx->command_complete_callback) {
-				ctx->command_complete_callback(pd->cmd_id);
+				ctx->command_complete_callback(ctx->command_complete_callback_arg,
+							       pd->cmd_id);
 			}
 			if (sc_is_active(pd)) {
 				pd->sc_tstamp = osdp_millis_now();

--- a/src/osdp_pd.c
+++ b/src/osdp_pd.c
@@ -1046,7 +1046,8 @@ static void osdp_pd_update(struct osdp_pd *pd)
 
 	osdp_phy_state_reset(pd, false);
 	if (ctx->command_complete_callback) {
-		ctx->command_complete_callback(pd->cmd_id);
+		ctx->command_complete_callback(ctx->command_complete_callback_arg, 
+					       pd->cmd_id);
 	}
 }
 


### PR DESCRIPTION
Added opaque pointer argument to command complete callback, so at this way we can pass a context or instance class to be able to access to class members. This is similar to command or event callbacks behavior, we pass the void *arg to the callbacks.