### PR TITLE
Fix implicit fallthrough in `pd_translate_event`

### DIFF
--- a/src/osdp_pd.c
+++ b/src/osdp_pd.c
@@ -163,6 +163,7 @@ static int pd_translate_event(struct osdp_pd *pd, struct osdp_event *event)
 		break;
 	case OSDP_EVENT_MFGREP:
 		reply_code = REPLY_MFGREP;
+		break;
 	default:
 		LOG_ERR("Unknown event type %d", event->type);
 		break;


### PR DESCRIPTION
See https://github.com/goToMain/libosdp/actions/runs/3650442394/jobs/6166438430 failing on master. I'm not exactly sure why the other failure is happening.