### PR TITLE
Fix cmake package file

### DIFF
--- a/cmake/LibOSDPConfig.cmake.in
+++ b/cmake/LibOSDPConfig.cmake.in
@@ -4,33 +4,16 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
-# Use the following variables to compile and link against LIBOSDP:
-#
-#  LIBOSDP_FOUND              - True if LibOSDP was found on your system
-#  LIBOSDP_DEFINITIONS        - Definitions needed to build with LibOSDP
-#  LIBOSDP_CMAKE_CONFIG_DIR   - Cmake configuration files install directory
-#  LIBOSDP_INCLUDE_DIR        - Directory where osdp.h can be found
-#  LIBOSDP_LIBRARY            - LibOSDP shared library name
-#  LIBOSDP_LIBRARY_STATIC     - LibOSDP static library name
-#  LIBOSDP_LIBRARY_DIR        - Directory containing LibOSDP library
-#  LIBOSDP_ROOT_DIR           - The base directory of LibOSDP
-#
-#  LIBOSDP_VERSION_STRING     - A human-readable string containing the version
-#  LIBOSDP_VERSION_MAJOR      - The major version of LibOSDP
-#  LIBOSDP_VERSION_MINOR      - The minor version of LibOSDP
-#  LIBOSDP_VERSION_PATCH      - The patch version of LibOSDP
+@PACKAGE_INIT@
 
-set(LIBOSDP_FOUND 1)
-set(LIBOSDP_ROOT_DIR         "@LIBOSDP_ROOT_DIR@")
-set(LIBOSDP_DEFINITIONS      "@LIBOSDP_DEFINITIONS@")
-set(LIBOSDP_CMAKE_CONFIG_DIR "@LIBOSDP_ROOT_DIR@/@LIBOSDP_CMAKE_CONFIG_DIR@")
-set(LIBOSDP_INCLUDE_DIR      "@LIBOSDP_ROOT_DIR@/@LIBOSDP_INCLUDE_DIR@")
-set(LIBOSDP_LIBRARY          "@LIBOSDP_LIBRARY@")
-set(LIBOSDP_LIBRARY_STATIC   "@LIBOSDP_LIBRARY_STATIC@")
-set(LIBOSDP_LIBRARY_DIR      "@LIBOSDP_ROOT_DIR@/@LIBOSDP_LIBRARY_DIR@")
-set(LIBOSDP_USE_FILE         "@LIBOSDP_ROOT_DIR@/@LIBOSDP_USE_FILE@")
+include("${CMAKE_CURRENT_LIST_DIR}/LibOSDPTargets.cmake")
 
-set(LIBOSDP_VERSION_STRING   "@LIBOSDP_VERSION_STRING@")
-set(LIBOSDP_VERSION_MAJOR    @LIBOSDP_VERSION_MAJOR@)
-set(LIBOSDP_VERSION_MINOR    @LIBOSDP_VERSION_MINOR@)
-set(LIBOSDP_VERSION_PATCH    @LIBOSDP_VERSION_PATCH@)
+if(@OpenSSL_FOUND@)
+  include(CMakeFindDependencyMacro)
+  find_dependency(OpenSSL)
+endif()
+
+if(@MbedTLS_FOUND@)
+  include(CMakeFindDependencyMacro)
+  find_dependency(MbedTLS)
+endif()

--- a/osdpctl/CMakeLists.txt
+++ b/osdpctl/CMakeLists.txt
@@ -16,10 +16,8 @@ list(APPEND BIN_OSDPCTL_SRC
 	cmd_others.c
 )
 
-find_package(LibOSDP NO_MODULE REQUIRED HINTS ${CMAKE_BINARY_DIR})
-
 add_executable(${BIN_OSDPCTL} ${BIN_OSDPCTL_SRC})
-target_link_libraries(${BIN_OSDPCTL} ${LIBOSDP_LIBRARY} utils pthread)
+target_link_libraries(${BIN_OSDPCTL} osdp utils pthread)
 target_include_directories(${BIN_OSDPCTL}
 	PUBLIC
 		${PROJECT_SOURCE_DIR}/utils/include

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -31,7 +31,8 @@ pyosdp_sources = '@LIB_OSDP_SOURCES@'.split(';') + [
 
 sources = utils_sources + pyosdp_sources
 
-libosdp_include_dirs = ('@LIB_OSDP_INCLUDE_DIRS@'.split(';') +
+libosdp_include_dirs = ('@PROJECT_SOURCE_DIR@/utils/include'.split(';') +
+                        '@PROJECT_SOURCE_DIR@/include'.split(';') +
                         '@LIB_OSDP_PRIVATE_INCLUDE_DIRS@'.split(';'))
 
 libosdp_includes = [ '-I' + path for path in libosdp_include_dirs ]
@@ -39,7 +40,6 @@ libosdp_includes = [ '-I' + path for path in libosdp_include_dirs ]
 libosdp_definitions = '@LIB_OSDP_DEFINITIONS@'.split(';')
 
 libosdp_libraries = '@LIB_OSDP_LIBRARIES@'.split(';')
-libosdp_libraries = libosdp_libraries[1:] # remove utils
 
 compile_args = libosdp_includes + libosdp_definitions
 

--- a/samples/c/CMakeLists.txt
+++ b/samples/c/CMakeLists.txt
@@ -10,16 +10,7 @@ project(osdp_c_sample)
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 	# This sample is built individually so try to locate an installed
 	# version of libosdp.
-	find_package(LibOSDP NO_MODULE REQUIRED)
-	include(${LIBOSDP_USE_FILE})
-else()
-	# sample is build from within libosdp as a subdir so try to look
-	# inside build dirs
-	find_package(LibOSDP NO_MODULE REQUIRED HINTS ${CMAKE_BINARY_DIR})
-
-	add_definitions(${LIBOSDP_DEFINITIONS})
-	include_directories(${LIBOSDP_INCLUDE_DIR})
-	link_directories(${LIBOSDP_LIBRARY_DIR})
+	find_package(libosdp NO_MODULE REQUIRED)
 endif()
 
 set(CP_SAMPLE c_cp_sample)
@@ -30,5 +21,5 @@ include_directories(${LIBOSDP_INCLUDE_DIR} ${CMAKE_SOURCE_DIRECTORY}/include)
 add_executable(${CP_SAMPLE} cp_app.c)
 add_executable(${PD_SAMPLE} pd_app.c)
 
-target_link_libraries(${CP_SAMPLE} ${LIBOSDP_LIBRARY})
-target_link_libraries(${PD_SAMPLE} ${LIBOSDP_LIBRARY})
+target_link_libraries(${CP_SAMPLE} osdp)
+target_link_libraries(${PD_SAMPLE} osdp)

--- a/samples/cpp/CMakeLists.txt
+++ b/samples/cpp/CMakeLists.txt
@@ -10,26 +10,15 @@ project(osdp_cpp_sample)
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 	# This sample is built individually so try to locate an installed
 	# version of libosdp.
-	find_package(LibOSDP NO_MODULE REQUIRED)
-	include(${LIBOSDP_USE_FILE})
-else()
-	# sample is build from within libosdp as a subdir so try to look
-	# inside build dirs
-	find_package(LibOSDP NO_MODULE REQUIRED HINTS ${CMAKE_BINARY_DIR})
-
-	add_definitions(${LIBOSDP_DEFINITIONS})
-	include_directories(${LIBOSDP_INCLUDE_DIR})
-	link_directories(${LIBOSDP_LIBRARY_DIR})
+	find_package(libosdp NO_MODULE REQUIRED)
 endif()
 
 set(CMAKE_CXX_STANDARD 11)
 set(CP_SAMPLE cpp_cp_sample)
 set(PD_SAMPLE cpp_pd_sample)
 
-include_directories(${LIBOSDP_INCLUDE_DIR} ${CMAKE_SOURCE_DIRECTORY}/include)
-
 add_executable(${CP_SAMPLE} cp_app.cpp)
 add_executable(${PD_SAMPLE} pd_app.cpp)
 
-target_link_libraries(${CP_SAMPLE} ${LIBOSDP_LIBRARY})
-target_link_libraries(${PD_SAMPLE} ${LIBOSDP_LIBRARY})
+target_link_libraries(${CP_SAMPLE} osdp)
+target_link_libraries(${PD_SAMPLE} osdp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,8 @@ find_package(OpenSSL)
 
 if (NOT OpenSSL_FOUND)
 	find_package(MbedTLS)
+else()
+	set(MbedTLS_FOUND FALSE)
 endif()
 
 # Generate osdp_config.h in build dir.
@@ -59,28 +61,16 @@ if (NOT CONFIG_OSDP_STATIC_PD)
 	)
 endif()
 
-list(APPEND LIB_OSDP_INCLUDE_DIRS
-	${PROJECT_SOURCE_DIR}/utils/include
-	${PROJECT_SOURCE_DIR}/include
-)
-
 list(APPEND LIB_OSDP_PRIVATE_INCLUDE_DIRS
 	${CMAKE_CURRENT_SOURCE_DIR}
 	${CMAKE_CURRENT_BINARY_DIR}
 )
 
-list(APPEND LIB_OSDP_LIBRARIES
-	utils
-)
-
 if (OpenSSL_FOUND)
-	list(APPEND LIB_OSDP_INCLUDE_DIRS ${OPENSSL_INCLUDE_DIR})
-	list(APPEND LIB_OSDP_LIBRARIES ${OPENSSL_CRYPTO_LIBRARY})
+	list(APPEND LIB_OSDP_LIBRARIES ${OPENSSL_CRYPTO_LIBRARY}) # Needed for python library building
 	list(APPEND LIB_OSDP_DEFINITIONS "-DCONFIG_OSDP_USE_OPENSSL")
 	list(APPEND LIB_OSDP_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/crypto/openssl.c)
 elseif (MbedTLS_FOUND)
-	list(APPEND LIB_OSDP_INCLUDE_DIRS ${MBEDTLS_INCLUDE_DIRS})
-	list(APPEND LIB_OSDP_LIBRARIES ${MBEDCRYPTO_LIBRARY})
 	list(APPEND LIB_OSDP_DEFINITIONS "-DCONFIG_OSDP_USE_MBEDTLS")
 	list(APPEND LIB_OSDP_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/crypto/mbedtls.c)
 else()
@@ -106,10 +96,11 @@ target_link_libraries(${LIB_OSDP_STATIC} ${LIB_OSDP_LIBRARIES})
 
 target_include_directories(${LIB_OSDP_STATIC}
 	PUBLIC
-		$<INSTALL_INTERFACE:include>
-		${LIB_OSDP_INCLUDE_DIRS}
+		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+		$<INSTALL_INTERFACE:include/libosdp>
 	PRIVATE
 		${LIB_OSDP_PRIVATE_INCLUDE_DIRS}
+		${PROJECT_SOURCE_DIR}/utils/include
 )
 
 ## build libosdp.so
@@ -139,9 +130,9 @@ set(LIB_OSDP_UTILS_SRC ${LIB_OSDP_UTILS_SRC} PARENT_SCOPE)
 # add source files of utils instead of linking it. See comment above.
 add_library(${LIB_OSDP_SHARED} SHARED ${LIB_OSDP_SOURCES} ${LIB_OSDP_UTILS_SRC})
 if (OpenSSL_FOUND)
-	target_link_libraries(${LIB_OSDP_SHARED} ${OPENSSL_CRYPTO_LIBRARY})
+	target_link_libraries(${LIB_OSDP_SHARED} PUBLIC OpenSSL::Crypto)
 elseif (MbedTLS_FOUND)
-	target_link_libraries(${LIB_OSDP_SHARED} ${MBEDCRYPTO_LIBRARY})
+	target_link_libraries(${LIB_OSDP_SHARED} PUBLIC MbedTLS::mbedcrypto)
 endif()
 
 set_target_properties(${LIB_OSDP_SHARED} PROPERTIES
@@ -152,10 +143,11 @@ set_target_properties(${LIB_OSDP_SHARED} PROPERTIES
 
 target_include_directories(${LIB_OSDP_SHARED}
 	PUBLIC
-		$<INSTALL_INTERFACE:include>
-		${LIB_OSDP_INCLUDE_DIRS}
+		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+		$<INSTALL_INTERFACE:include/libosdp>
 	PRIVATE
 		${LIB_OSDP_PRIVATE_INCLUDE_DIRS}
+		${PROJECT_SOURCE_DIR}/utils/include
 )
 
 # generate osdp_export.h for OSDP_EXPORT() macro
@@ -173,41 +165,6 @@ if (CONFIG_BUILD_ASAN)
 	target_link_options(${LIB_OSDP_STATIC} PRIVATE -fsanitize=address)
 endif()
 
-## Package Configuration
-
-include(CMakePackageConfigHelpers)
-set(LIBOSDP_CMAKE_CONFIG_DIR "lib/cmake/libosdp")
-set(LIBOSDP_PKG_CONFIG_DIR   "lib/pkgconfig")
-set(LIBOSDP_DEFINITIONS      ${LIB_OSDP_DEFINITIONS})
-set(LIBOSDP_INCLUDE_DIR      "include")
-set(LIBOSDP_LIBRARY          ${LIB_OSDP_SHARED})
-set(LIBOSDP_LIBRARY_STATIC   ${LIB_OSDP_STATIC})
-set(LIBOSDP_LIBRARY_DIR      "lib")
-set(LIBOSDP_USE_FILE         "lib/cmake/libosdp/UseLibOSDP.cmake")
-set(LIBOSDP_ROOT_DIR         ${CMAKE_INSTALL_PREFIX})
-set(LIBOSDP_VERSION_STRING   ${PROJECT_VERSION})
-set(LIBOSDP_VERSION_MAJOR    ${PROJECT_VERSION_MAJOR})
-set(LIBOSDP_VERSION_MINOR    ${PROJECT_VERSION_MINOR})
-set(LIBOSDP_VERSION_PATCH    ${PROJECT_VERSION_PATCH})
-
-configure_package_config_file(
-	${PROJECT_SOURCE_DIR}/cmake/LibOSDPConfig.cmake.in
-	${CMAKE_BINARY_DIR}/LibOSDPConfig.cmake
-	INSTALL_DESTINATION ${LIBOSDP_CMAKE_CONFIG_DIR}
-	PATH_VARS
-		LIBOSDP_ROOT_DIR
-		LIBOSDP_INCLUDE_DIR
-		LIBOSDP_LIBRARY_DIR
-	NO_CHECK_REQUIRED_COMPONENTS_MACRO
-	INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}
-)
-
-write_basic_package_version_file (
-	${CMAKE_BINARY_DIR}/LibOSDPConfigVersion.cmake
-	VERSION ${PROJECT_VERSION}
-	COMPATIBILITY AnyNewerVersion
-)
-
 # pkg-config file
 configure_file(
 	${PROJECT_SOURCE_DIR}/misc/libosdp.pc.in
@@ -218,22 +175,40 @@ configure_file(
 
 install(
 	TARGETS ${LIB_OSDP_SHARED} ${LIB_OSDP_STATIC}
+	COMPONENT distributables
+	EXPORT LibOSDPTargets
 	LIBRARY DESTINATION ${LIBOSDP_LIBRARY_DIR}
 	ARCHIVE DESTINATION ${LIBOSDP_LIBRARY_DIR}
-	PUBLIC_HEADER DESTINATION ${LIBOSDP_INCLUDE_DIR}
-	COMPONENT distributabes
-)
-install(
-	FILES
-		${CMAKE_BINARY_DIR}/LibOSDPConfig.cmake
-		${CMAKE_BINARY_DIR}/LibOSDPConfigVersion.cmake
-		${PROJECT_SOURCE_DIR}/cmake/UseLibOSDP.cmake
-	DESTINATION ${LIBOSDP_CMAKE_CONFIG_DIR}
-	COMPONENT config_files
+	PUBLIC_HEADER DESTINATION include/libosdp
 )
 install(
 	FILES
 		${CMAKE_BINARY_DIR}/libosdp.pc
-	DESTINATION ${LIBOSDP_PKG_CONFIG_DIR}
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 	COMPONENT config_files
+)
+
+## Package Configuration
+
+include(CMakePackageConfigHelpers)
+install(EXPORT LibOSDPTargets
+	FILE LibOSDPTargets.cmake
+	NAMESPACE libosdp::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libosdp
+)
+configure_package_config_file(
+	${PROJECT_SOURCE_DIR}/cmake/LibOSDPConfig.cmake.in
+	${CMAKE_BINARY_DIR}/LibOSDPConfig.cmake
+	INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libosdp
+	NO_CHECK_REQUIRED_COMPONENTS_MACRO
+	INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}
+)
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/LibOSDPConfigVersion.cmake"
+	VERSION ${PROJECT_VERSION}
+	COMPATIBILITY SameMajorVersion
+)
+install(FILES
+          "${CMAKE_BINARY_DIR}/LibOSDPConfig.cmake"
+          "${CMAKE_CURRENT_BINARY_DIR}/LibOSDPConfigVersion.cmake"
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libosdp
 )

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -28,7 +28,8 @@ add_executable(${OSDP_UNIT_TEST} EXCLUDE_FROM_ALL ${OSDP_UNIT_TEST_SRC})
 
 target_link_libraries(${OSDP_UNIT_TEST}
 		      ${LIB_OSDP_TEST}
-		      ${LIB_OSDP_LIBRARIES}
+		      osdp
+		      utils
 		      pthread)
 
 include_directories(


### PR DESCRIPTION
Fix for #107 

When using libosdp, you can now link in cmake with:

```
find_package(LibOSDP)
target_link_libraries( target-name PRIVATE libosdp::osdp)
```