### PR TITLE
Python Bindings: CP add CMD_STATUS support

### DIFF
--- a/python/pyosdp.c
+++ b/python/pyosdp.c
@@ -42,6 +42,7 @@ void pyosdp_add_module_constants(PyObject *module)
 	ADD_CONST("CMD_KEYSET", OSDP_CMD_KEYSET);
 	ADD_CONST("CMD_MFG", OSDP_CMD_MFG);
 	ADD_CONST("CMD_FILE_TX", OSDP_CMD_FILE_TX);
+	ADD_CONST("CMD_STATUS", OSDP_CMD_STATUS);
 
 	/* For `struct osdp_cmd_file_tx`::flags */
 	ADD_CONST("CMD_FILE_TX_FLAG_CANCEL", OSDP_CMD_FILE_TX_FLAG_CANCEL);

--- a/python/pyosdp_data.c
+++ b/python/pyosdp_data.c
@@ -363,7 +363,11 @@ static int pyosdp_make_struct_cmd_file_tx(struct osdp_cmd *p, PyObject *dict)
 }
 
 /* Dummies for commands that don't have any body */
-static int pyosdp_make_struct_cmd_dummy(struct osdp_cmd *cmd, PyObject *obj) { return 0; }
+static int pyosdp_make_struct_cmd_dummy(struct osdp_cmd *cmd, PyObject *obj) { 
+	cmd->id = OSDP_CMD_STATUS;
+
+	return 0; 
+}
 static int pyosdp_make_dict_cmd_dummy(PyObject *obj, struct osdp_cmd *cmd) { return 0; }
 
 


### PR DESCRIPTION
I ran into an incompatibility when trying to use some new functionality in the Python bindings: https://github.com/goToMain/libosdp/issues/105

Currently `osdp.CMD_STATUS` is not exposed to the user of the Python bindings.

Additionally, the evaluated enum value is discarded by `pyosdp_make_struct_cmd_dummy`.