### PR TITLE
Add support for additional baud rate 57600

### DIFF
--- a/doc/protocol/introduction.rst
+++ b/doc/protocol/introduction.rst
@@ -20,7 +20,7 @@ Signaling
 ---------
 
 Half duplex asynchronous serial 8 data bits, 1 stop bit, no parity bits, with
-either one of 9600, 19200, 38400, 115200 or 230400 baud rates.
+either one of 9600, 19200, 38400, 57600, 115200 or 230400 baud rates.
 
 Character Encoding
 ------------------

--- a/include/osdp.h
+++ b/include/osdp.h
@@ -300,7 +300,7 @@ struct osdp_channel {
  * @brief OSDP PD Information. This struct is used to describe a PD to LibOSDP.
  *
  * @param name User provided name for this PD (log messages include this name)
- * @param baud_rate Can be one of 9600/19200/38400/115200/230400
+ * @param baud_rate Can be one of 9600/19200/38400/57600/115200/230400
  * @param address 7 bit PD address. the rest of the bits are ignored. The
  *        special address 0x7F is used for broadcast. So there can be 2^7-1
  *        devices on a multi-drop channel
@@ -462,7 +462,7 @@ struct osdp_cmd_text {
  *
  * @param address Unit ID to which this PD will respond after the change takes
  *        effect.
- * @param baud_rate baud rate value 9600/19200/38400/115200/230400
+ * @param baud_rate baud rate value 9600/19200/38400/57600/115200/230400
  */
 struct osdp_cmd_comset {
 	uint8_t address;

--- a/osdpctl/cmd_send.c
+++ b/osdpctl/cmd_send.c
@@ -196,8 +196,8 @@ int handle_cmd_comset(int argc, char *argv[], struct osdp_cmd_comset *c)
 	if (address <= 0 || address >= 126)
 		return -1;
 
-	if (baud != 9600 && baud != 19200 && baud != 38400 && baud != 57600 && 
-		baud != 115200 && baud != 230400)
+	if (baud != 9600 && baud != 19200 && baud != 38400 && baud != 57600 &&
+	    baud != 115200 && baud != 230400)
 		return -1;
 
 	c->address = (uint8_t)address;

--- a/osdpctl/cmd_send.c
+++ b/osdpctl/cmd_send.c
@@ -196,8 +196,8 @@ int handle_cmd_comset(int argc, char *argv[], struct osdp_cmd_comset *c)
 	if (address <= 0 || address >= 126)
 		return -1;
 
-	if (baud != 9600 && baud != 19200 && baud != 38400 && baud != 115200 &&
-	    baud != 230400)
+	if (baud != 9600 && baud != 19200 && baud != 38400 && baud != 57600 && 
+		baud != 115200 && baud != 230400)
 		return -1;
 
 	c->address = (uint8_t)address;

--- a/osdpctl/config.c
+++ b/osdpctl/config.c
@@ -151,8 +151,8 @@ int config_parse_key_channel_speed(const char *val, void *data)
 	if (safe_atoi(val, &baud))
 		return INI_FAILURE;
 
-	if (baud != 9600 && baud != 19200 && baud != 38400 && baud != 115200 &&
-	    baud != 230400) {
+	if (baud != 9600 && baud != 19200 && baud != 38400 && baud != 57600 &&
+		baud != 115200 && baud != 230400) {
 		printf("Error: invalid baudrate %d\n", baud);
 		return INI_FAILURE;
 	}

--- a/osdpctl/config.c
+++ b/osdpctl/config.c
@@ -152,7 +152,7 @@ int config_parse_key_channel_speed(const char *val, void *data)
 		return INI_FAILURE;
 
 	if (baud != 9600 && baud != 19200 && baud != 38400 && baud != 57600 &&
-		baud != 115200 && baud != 230400) {
+	    baud != 115200 && baud != 230400) {
 		printf("Error: invalid baudrate %d\n", baud);
 		return INI_FAILURE;
 	}

--- a/src/osdp_pd.c
+++ b/src/osdp_pd.c
@@ -470,6 +470,7 @@ static int pd_decode_command(struct osdp_pd *pd, uint8_t *buf, int len)
 		    (cmd.comset.baud_rate != 9600 &&
 		     cmd.comset.baud_rate != 19200 &&
 		     cmd.comset.baud_rate != 38400 &&
+		     cmd.comset.baud_rate != 57600 &&
 		     cmd.comset.baud_rate != 115200 &&
 		     cmd.comset.baud_rate != 230400)) {
 			LOG_ERR("COMSET Failed! command discarded");


### PR DESCRIPTION
According specification, half-duplex asynchronous serial should support at least one of 9600, 19200, 38400, 57600, 115200, 230400 Baud. Adding support for 57600.