### PR TITLE
Adding ./configure.sh to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ that are exposed by libosdp.
 git clone https://github.com/goToMain/libosdp --recurse-submodules
 # git submodule update --init (if you missed doing --recurse-submodules earlier)
 cd libosdp
+./configure.sh
 mkdir build && cd build
 cmake ..
 make

--- a/doc/libosdp/build-and-install.rst
+++ b/doc/libosdp/build-and-install.rst
@@ -7,7 +7,7 @@ these with your application as needed (-losdp or -losdpstatic). Have a look at
 ``sample/*`` for details on how to consume this library.
 
 .. code:: sh
-
+    ./configure.sh
     mkdir build && cd build
     cmake ..
     make


### PR DESCRIPTION
Adding `./configure.sh` to the build instructions.  Failing to run it results in the utils dir not being created and CMake failing.