### PR TITLE
C++ wrapper, only call teardown in destructors if context exists

### DIFF
--- a/include/osdp.hpp
+++ b/include/osdp.hpp
@@ -111,11 +111,14 @@ class PeripheralDevice : public Common {
 public:
 	PeripheralDevice()
 	{
+		_ctx = nullptr;
 	}
 
 	~PeripheralDevice()
 	{
-		osdp_pd_teardown(_ctx);
+		if (_ctx) {
+			osdp_pd_teardown(_ctx);
+		}
 	}
 
 	bool setup(osdp_pd_info_t *info)

--- a/include/osdp.hpp
+++ b/include/osdp.hpp
@@ -64,11 +64,14 @@ class ControlPanel : public Common {
 public:
 	ControlPanel()
 	{
+		_ctx = nullptr;
 	}
 
 	~ControlPanel()
 	{
-		osdp_cp_teardown(_ctx);
+		if (_ctx) {
+			osdp_cp_teardown(_ctx);
+		}
 	}
 
 	bool setup(int num_pd, osdp_pd_info_t *info)


### PR DESCRIPTION
Fixes #129.

Adds a check to the destructors of **OSDP::ControlPanel** and **OSDP::Peripheral** to see if the context has been set during the object's lifetime. This decides whether a teardown should happen or not. An uninitialized object would otherwise fail when being destroyed.