### PR TITLE
Give PD the ability to detect offline

### DIFF
--- a/include/osdp.h
+++ b/include/osdp.h
@@ -997,6 +997,9 @@ const char *osdp_get_source_info();
 
 /**
  * @brief Get a bit mask of number of PD that are online currently.
+ * When calling this function as a PD, only the first bit is valid.
+ * If the PD has not received a message from the CP recently,
+ * the status will be 0.
  *
  * @param ctx OSDP context
  * @param bitmask pointer to an array of bytes. must be as large as
@@ -1007,6 +1010,7 @@ void osdp_get_status_mask(osdp_t *ctx, uint8_t *bitmask);
 /**
  * @brief Get a bit mask of number of PD that are online and have an active
  * secure channel currently.
+ * When calling this function as a PD, only the first bit is valid.
  *
  * @param ctx OSDP context
  * @param bitmask pointer to an array of bytes. must be as large as

--- a/src/osdp_common.c
+++ b/src/osdp_common.c
@@ -265,8 +265,7 @@ void osdp_get_status_mask(osdp_t *ctx, uint8_t *bitmask)
 			*mask = 0;
 		}
 		pd = osdp_to_pd(ctx, i);
-		if (ISSET_FLAG(pd, PD_FLAG_PD_MODE) ||
-		    pd->state == OSDP_CP_STATE_ONLINE) {
+		if (pd->state == OSDP_CP_STATE_ONLINE) {
 			*mask |= 1 << pos;
 		}
 	}

--- a/src/osdp_common.h
+++ b/src/osdp_common.h
@@ -304,12 +304,13 @@ struct osdp_pd {
 	/* PD Capability; Those received from app + implicit capabilities */
 	struct osdp_pd_cap cap[OSDP_PD_CAP_SENTINEL];
 
-	int state;             /* FSM state (CP mode only) */
+	int state;             /* FSM state */
 	int phy_state;         /* phy layer FSM state (CP mode only) */
 	uint32_t wait_ms;      /* wait time in MS to retry communication */
 	int64_t tstamp;        /* Last POLL command issued time in ticks */
 	int64_t sc_tstamp;     /* Last received secure reply time in ticks */
 	int64_t phy_tstamp;    /* Time in ticks since command was sent */
+	int64_t rx_tstamp;     /* Last time we rx a message in ticks */
 
 	uint16_t peer_rx_size; /* Receive buffer size of the peer PD/CP */
 

--- a/src/osdp_config.h.in
+++ b/src/osdp_config.h.in
@@ -25,6 +25,7 @@
 #define OSDP_PD_SC_RETRY_MS                     (600 * 1000)
 #define OSDP_PD_POLL_TIMEOUT_MS                 (50)
 #define OSDP_PD_SC_TIMEOUT_MS                   (800)
+#define OSDP_PD_RX_TIMEOUT_MS                   (800)
 #define OSDP_RESP_TOUT_MS                       (200)
 #define OSDP_ONLINE_RETRY_WAIT_MAX_MS           (300 * 1000)
 #define OSDP_CMD_RETRY_WAIT_MS                  (300)


### PR DESCRIPTION
If the PD does not receive a message from the CP(any message, including a poll), then it will now indicate that it is offline through the osdp_get_status_mask method.