### PR TITLE
c++: add header guards

### DIFF
--- a/include/osdp.hpp
+++ b/include/osdp.hpp
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#ifndef LIBOSDP_OSDP_HPP_
+#define LIBOSDP_OSDP_HPP_
+
 #include <osdp.h>
 
 /**
@@ -149,3 +152,5 @@ public:
 };
 
 }; /* namespace OSDP */
+
+#endif // LIBOSDP_OSDP_HPP_


### PR DESCRIPTION
Add header guards to osdp.hpp to prevent multiple inclusions of the same header file. osdp.h already has this.