### PR TITLE
Feature/gcc warning errors

### DIFF
--- a/src/osdp_common.c
+++ b/src/osdp_common.c
@@ -3,9 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#define _GNU_SOURCE /* See feature_test_macros(7) */
-
 #include <stdarg.h>
 #include <stdlib.h>
 #ifndef CONFIG_DISABLE_PRETTY_LOGGING


### PR DESCRIPTION
Hi,

I'm trying to integrate your library into another project using gcc 8.4.0 with '-Werror'. This gives some small issues. Would it be possible to integrate my changes?

This affects both the library as items into your submodule 'utils'. I create a separate pull request for that.

Logically you can skip the changes to link to my fork, but this allows me to do a full integration myself. 

In case you accept my changes I can safely use the upstream version.

Let me know your thoughts.

Thanks in advance.

Kr,
Bart.