### PR TITLE
rust: no_std support

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,6 +20,7 @@ bindgen = "0.68.1"
 
 [dependencies]
 bitflags = "2.4.0"
+embedded-io = "0.6.1"
 env_logger = "0.10.0"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 log = "0.4.20"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,12 +21,14 @@ bindgen = "0.68.1"
 [dependencies]
 bitflags = "2.4.0"
 env_logger = "0.10.0"
-lazy_static = "1.4.0"
+lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 log = "0.4.20"
 multiqueue = "0.3.2"
 once_cell = "1.18.0"
+parking_lot = "0.12.1"
 serde = { version = "1.0.192", features = ["derive"] }
 serde_with = "3.4.0"
+spin = "0.9.8"
 thiserror = "1.0.50"
 
 [features]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,3 +28,7 @@ once_cell = "1.18.0"
 serde = { version = "1.0.192", features = ["derive"] }
 serde_with = "3.4.0"
 thiserror = "1.0.50"
+
+[features]
+default = ["std"]
+std = []

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -16,13 +16,13 @@ fn get_repo_root() -> std::io::Result<String> {
         let has_git = std::fs::read_dir(p)?
             .into_iter()
             .any(|p| {
-                let ent = p.unwrap();
-                if ent.file_type().unwrap().is_dir() {
-                    ent.file_name() == OsString::from(".git")
-                } else {
-                    false
-                }
-            });
+            let ent = p.unwrap();
+            if ent.file_type().unwrap().is_dir() {
+                ent.file_name() == OsString::from(".git")
+            } else {
+                false
+            }
+        });
         if has_git {
             return Ok(PathBuf::from(p).into_os_string().into_string().unwrap())
         }
@@ -32,8 +32,8 @@ fn get_repo_root() -> std::io::Result<String> {
     while let Some(p) = path_ancestors.next() {
         let has_cargo =
             std::fs::read_dir(p)?
-                .into_iter()
-                .any(|p| p.unwrap().file_name() == OsString::from("Cargo.lock"));
+            .into_iter()
+            .any(|p| p.unwrap().file_name() == OsString::from("Cargo.lock"));
         if has_cargo {
             return Ok(PathBuf::from(p).into_os_string().into_string().unwrap())
         }
@@ -107,13 +107,13 @@ fn generate_osdp_build_headers(out_dir: &str) -> Result<()> {
     std::fs::copy(&src, &dest)
         .context(format!("Failed: copy {src} -> {dest}"))?;
     configure_file(&dest, vec![
-        ("PROJECT_VERSION", env!("CARGO_PKG_VERSION")),
+            ("PROJECT_VERSION", env!("CARGO_PKG_VERSION")),
         ("PROJECT_NAME", format!("{}-rust", env!("CARGO_PKG_NAME")).as_str()),
-        ("GIT_BRANCH", git.branch.as_str()),
-        ("GIT_REV", git.rev.as_ref()),
-        ("GIT_TAG", git.tag.as_ref()),
-        ("GIT_DIFF", git.diff.as_ref()),
-        ("REPO_ROOT", git.root.as_ref()),
+            ("GIT_BRANCH", git.branch.as_str()),
+            ("GIT_REV", git.rev.as_ref()),
+            ("GIT_TAG", git.tag.as_ref()),
+            ("GIT_DIFF", git.diff.as_ref()),
+            ("REPO_ROOT", git.root.as_ref()),
     ])
 }
 
@@ -219,7 +219,8 @@ fn main() -> Result<()> {
     build.compile("libosdp.a");
 
     let bindings = bindgen::Builder::default()
-        .header( "vendor/include/osdp.h")
+        .use_core()
+        .header("vendor/include/osdp.h")
         .generate()
         .context("Unable to generate bindings")?;
 

--- a/rust/src/channel/mod.rs
+++ b/rust/src/channel/mod.rs
@@ -11,20 +11,22 @@
 //! This module provides a way to define an OSDP channel and export it to
 //! LibOSDP.
 
+#[cfg(feature = "std")]
 pub mod unix_channel;
+#[cfg(feature = "std")]
 pub use unix_channel::UnixChannel;
 
 use crate::osdp_sys;
 use lazy_static::lazy_static;
+#[cfg(not(feature = "std"))]
+use alloc::collections::BTreeMap as HashMap;
+use alloc::{boxed::Box, format, sync::Arc, vec};
 use core::{
     ffi::c_void,
     hash::{Hash, Hasher},
 };
-use std::{
-    collections::{hash_map::DefaultHasher, HashMap},
-    io::{Read, Write},
-    sync::{Mutex, Arc},
-};
+#[cfg(feature = "std")]
+use std::collections::{hash_map::DefaultHasher, HashMap};
 
 lazy_static! {
     static ref CHANNELS: Mutex<HashMap<i32, Arc<Mutex<Box<dyn Channel>>>>> = Mutex::new(HashMap::new());
@@ -112,6 +114,7 @@ impl OsdpChannel {
     }
 }
 
+#[cfg(feature = "std")]
 fn str_to_channel_id(key: &str) -> i32 {
     let mut hasher = DefaultHasher::new();
     key.hash(&mut hasher);

--- a/rust/src/channel/mod.rs
+++ b/rust/src/channel/mod.rs
@@ -16,7 +16,7 @@ pub mod unix_channel;
 #[cfg(feature = "std")]
 pub use unix_channel::UnixChannel;
 
-use crate::{osdp_sys, Mutex};
+use crate::osdp_sys;
 use lazy_static::lazy_static;
 #[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap as HashMap;
@@ -24,6 +24,11 @@ use alloc::{boxed::Box, format, sync::Arc, vec};
 use core::ffi::c_void;
 #[cfg(feature = "std")]
 use std::{collections::{hash_map::DefaultHasher, HashMap}, hash::{Hash, Hasher}};
+
+#[cfg(feature = "std")]
+use parking_lot::Mutex;
+#[cfg(not(feature = "std"))]
+use spin::Mutex;
 
 lazy_static! {
     static ref CHANNELS: Mutex<HashMap<i32, Arc<Mutex<Box<dyn Channel>>>>> =

--- a/rust/src/commands.rs
+++ b/rust/src/commands.rs
@@ -3,7 +3,8 @@
 //! such commands though [`OsdpCommand`].
 
 use crate::{osdp_sys, ConvertEndian};
-use serde::{Serialize, Deserialize};
+use alloc::vec::Vec;
+use serde::{Deserialize, Serialize};
 
 /// LED Colors as specified in OSDP for the on_color/off_color parameters.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/rust/src/cp.rs
+++ b/rust/src/cp.rs
@@ -8,22 +8,20 @@ use crate::{
     osdp_sys,
     OsdpError,
     PdInfo,
-    OsdpFlag,
-    PdCapability,
-    PdId,
 };
+use alloc::vec::Vec;
+use core::ffi::c_void;
 use log::{debug, error, info, warn};
-use std::ffi::c_void;
 
-type Result<T> = std::result::Result<T, OsdpError>;
+type Result<T> = core::result::Result<T, OsdpError>;
 type EventCallback =
     unsafe extern "C" fn(data: *mut c_void, pd: i32, event: *mut osdp_sys::osdp_event) -> i32;
 
 unsafe extern "C" fn log_handler(
-    log_level: ::std::os::raw::c_int,
-    _file: *const ::std::os::raw::c_char,
-    _line: ::std::os::raw::c_ulong,
-    msg: *const ::std::os::raw::c_char,
+    log_level: ::core::ffi::c_int,
+    _file: *const ::core::ffi::c_char,
+    _line: ::core::ffi::c_ulong,
+    msg: *const ::core::ffi::c_char,
 ) {
     let msg = crate::cstr_to_string(msg);
     let msg = msg.trim();
@@ -74,7 +72,7 @@ fn cp_setup(info: Vec<osdp_sys::osdp_pd_info_t>) -> Result<*mut c_void> {
 /// OSDP CP device context.
 #[derive(Debug)]
 pub struct ControlPanel {
-    ctx: *mut std::ffi::c_void,
+    ctx: *mut core::ffi::c_void,
 }
 
 impl ControlPanel {
@@ -149,7 +147,7 @@ impl ControlPanel {
     /// vector in [`ControlPanel::new`]).
     pub fn get_pd_id(&self, pd: i32) -> Result<PdId> {
         let mut pd_id: osdp_sys::osdp_pd_id =
-            unsafe { std::mem::MaybeUninit::zeroed().assume_init() };
+            unsafe { core::mem::MaybeUninit::zeroed().assume_init() };
         let rc = unsafe { osdp_sys::osdp_cp_get_pd_id(self.ctx, pd, &mut pd_id) };
         if rc < 0 {
             Err(OsdpError::Query("PdId"))

--- a/rust/src/cp.rs
+++ b/rust/src/cp.rs
@@ -1,12 +1,10 @@
 //! The CP is responsible to connecting to and managing multiple PDs. It is able
 //! to send commands to and receive events from PDs.
 
+#[cfg(feature = "std")]
+use crate::file::{impl_osdp_file_ops_for, OsdpFile, OsdpFileOps};
 use crate::{
-    commands::OsdpCommand,
-    events::OsdpEvent,
-    file::{OsdpFile, OsdpFileOps, impl_osdp_file_ops_for},
-    osdp_sys,
-    OsdpError,
+    commands::OsdpCommand, events::OsdpEvent, osdp_sys, OsdpError, OsdpFlag, PdCapability, PdId,
     PdInfo,
 };
 use alloc::vec::Vec;
@@ -206,4 +204,5 @@ impl Drop for ControlPanel {
     }
 }
 
+#[cfg(feature = "std")]
 impl_osdp_file_ops_for!(ControlPanel);

--- a/rust/src/events.rs
+++ b/rust/src/events.rs
@@ -4,9 +4,10 @@
 //! module is responsible to handling such events though [`OsdpEvent`].
 
 use crate::{osdp_sys, ConvertEndian, OsdpError};
-use serde::{Serialize, Deserialize};
+use alloc::vec::Vec;
+use serde::{Deserialize, Serialize};
 
-type Result<T> = std::result::Result<T, OsdpError>;
+type Result<T> = core::result::Result<T, OsdpError>;
 
 /// Various card formats that a PD can support. This is sent to CP when a PD
 /// must report a card read

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -83,11 +83,15 @@ pub mod file;
 mod osdp_sys;
 
 use alloc::{borrow::ToOwned, ffi::CString, format, str::FromStr, string::String, vec, vec::Vec};
-use std::sync::Mutex;
 use channel::OsdpChannel;
 use once_cell::sync::Lazy;
 #[cfg(feature = "std")]
 use thiserror::Error;
+
+#[cfg(feature = "std")]
+use parking_lot::Mutex;
+#[cfg(not(feature = "std"))]
+use spin::Mutex;
 
 /// OSDP public errors
 #[derive(Debug, Default)]
@@ -154,12 +158,12 @@ static SOURCE_INFO: Lazy<Mutex<String>> = Lazy::new(|| {
 
 /// Get LibOSDP version
 pub fn get_version() -> String {
-    VERSION.lock().unwrap().clone()
+    VERSION.lock().clone()
 }
 
 /// Get LibOSDP source info string
 pub fn get_source_info() -> String {
-    SOURCE_INFO.lock().unwrap().clone()
+    SOURCE_INFO.lock().clone()
 }
 
 /// PD ID information advertised by the PD.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -81,7 +81,8 @@ pub mod channel;
 pub mod file;
 mod osdp_sys;
 
-use std::{str::FromStr, ffi::CString, sync::Mutex};
+use alloc::{borrow::ToOwned, ffi::CString, format, str::FromStr, string::String, vec, vec::Vec};
+use std::sync::Mutex;
 use channel::OsdpChannel;
 use once_cell::sync::Lazy;
 use thiserror::Error;
@@ -127,16 +128,14 @@ pub enum OsdpError {
     Unknown,
 }
 
-impl From<std::convert::Infallible> for OsdpError {
-    fn from(_: std::convert::Infallible) -> Self {
+impl From<core::convert::Infallible> for OsdpError {
+    fn from(_: core::convert::Infallible) -> Self {
         unreachable!()
     }
 }
 
-fn cstr_to_string(s: *const ::std::os::raw::c_char) -> String {
-    let s = unsafe {
-        std::ffi::CStr::from_ptr(s)
-    };
+fn cstr_to_string(s: *const ::core::ffi::c_char) -> String {
+    let s = unsafe { core::ffi::CStr::from_ptr(s) };
     s.to_str().unwrap().to_owned()
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 //! # LibOSDP - Open Supervised Device Protocol Library
 //!
 //! This is an open source implementation of IEC 60839-11-5 Open Supervised
@@ -73,6 +74,8 @@
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
 
+extern crate alloc;
+
 pub mod cp;
 pub mod pd;
 pub mod commands;
@@ -82,7 +85,10 @@ pub mod channel;
 pub mod file;
 mod osdp_sys;
 
-use alloc::{borrow::ToOwned, ffi::CString, format, str::FromStr, string::String, vec, vec::Vec};
+#[allow(unused_imports)]
+use alloc::{
+    borrow::ToOwned, boxed::Box, ffi::CString, format, str::FromStr, string::String, vec, vec::Vec,
+};
 use channel::OsdpChannel;
 use once_cell::sync::Lazy;
 #[cfg(feature = "std")]
@@ -129,6 +135,9 @@ pub enum OsdpError {
     #[cfg(feature = "std")]
     #[error("IO Error")]
     IO(#[from] std::io::Error),
+    /// IO Error
+    #[cfg(not(feature = "std"))]
+    IO(Box<dyn embedded_io::Error>),
 
     /// Unknown error
     #[default]
@@ -358,15 +367,15 @@ impl FromStr for PdCapEntity {
 /// the CP by means of "capabilities".
 #[derive(Clone, Debug)]
 pub enum PdCapability {
-	/// This function indicates the ability to monitor the status of a switch
+    /// This function indicates the ability to monitor the status of a switch
     /// using a two-wire electrical connection between the PD and the switch.
     /// The on/off position of the switch indicates the state of an external
     /// device.
     ///
-	/// The PD may simply resolve all circuit states to an open/closed
-	/// status, or it may implement supervision of the monitoring circuit.
-	/// A supervised circuit is able to indicate circuit fault status in
-	/// addition to open/closed status.
+    /// The PD may simply resolve all circuit states to an open/closed
+    /// status, or it may implement supervision of the monitoring circuit.
+    /// A supervised circuit is able to indicate circuit fault status in
+    /// addition to open/closed status.
     ContactStatusMonitoring(PdCapEntity),
 
     /// This function provides a switched output, typically in the form of a

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -78,6 +78,7 @@ pub mod pd;
 pub mod commands;
 pub mod events;
 pub mod channel;
+#[cfg(feature = "std")]
 pub mod file;
 mod osdp_sys;
 
@@ -85,46 +86,49 @@ use alloc::{borrow::ToOwned, ffi::CString, format, str::FromStr, string::String,
 use std::sync::Mutex;
 use channel::OsdpChannel;
 use once_cell::sync::Lazy;
+#[cfg(feature = "std")]
 use thiserror::Error;
 
 /// OSDP public errors
-#[derive(Debug, Default, Error)]
+#[derive(Debug, Default)]
+#[cfg_attr(feature = "std", derive(Error))]
 pub enum OsdpError {
     /// PD info error
-    #[error("Invalid PdInfo {0}")]
+    #[cfg_attr(feature = "std", error("Invalid PdInfo {0}"))]
     PdInfo(&'static str),
 
     /// Command build/send error
-    #[error("Invalid OsdpCommand")]
+    #[cfg_attr(feature = "std", error("Invalid OsdpCommand"))]
     Command,
 
     /// Event build/send error
-    #[error("Invalid OsdpEvent")]
+    #[cfg_attr(feature = "std", error("Invalid OsdpEvent"))]
     Event,
 
     /// PD/CP status query error
-    #[error("Failed to query {0} from device")]
+    #[cfg_attr(feature = "std", error("Failed to query {0} from device"))]
     Query(&'static str),
-    #[error("File transfer failed: {0}")]
 
     /// File transfer errors
+    #[cfg_attr(feature = "std", error("File transfer failed: {0}"))]
     FileTransfer(&'static str),
 
     /// CP/PD device setup failed.
-    #[error("Failed to setup device")]
+    #[cfg_attr(feature = "std", error("Failed to setup device"))]
     Setup,
 
     /// String parse error
-    #[error("Type {0} parse error")]
+    #[cfg_attr(feature = "std", error("Type {0} parse error"))]
     Parse(String),
 
     /// IO Error
+    #[cfg(feature = "std")]
     #[error("IO Error")]
     IO(#[from] std::io::Error),
 
     /// Unknown error
     #[default]
-    #[error("Unknown/Unspecified error")]
+    #[cfg_attr(feature = "std", error("Unknown/Unspecified error"))]
     Unknown,
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -87,17 +87,12 @@ mod osdp_sys;
 
 #[allow(unused_imports)]
 use alloc::{
-    borrow::ToOwned, boxed::Box, ffi::CString, format, str::FromStr, string::String, vec, vec::Vec,
+    borrow::ToOwned, boxed::Box, ffi::CString, format, str::FromStr, string::String, sync::Arc, vec, vec::Vec,
 };
 use channel::OsdpChannel;
 use once_cell::sync::Lazy;
 #[cfg(feature = "std")]
 use thiserror::Error;
-
-#[cfg(feature = "std")]
-use parking_lot::Mutex;
-#[cfg(not(feature = "std"))]
-use spin::Mutex;
 
 /// OSDP public errors
 #[derive(Debug, Default)]
@@ -156,23 +151,23 @@ fn cstr_to_string(s: *const ::core::ffi::c_char) -> String {
     s.to_str().unwrap().to_owned()
 }
 
-static VERSION: Lazy<Mutex<String>> = Lazy::new(|| {
+static VERSION: Lazy<Arc<String>> = Lazy::new(|| {
     let s = unsafe { osdp_sys::osdp_get_version() };
-    Mutex::new(cstr_to_string(s))
+    Arc::new(cstr_to_string(s))
 });
-static SOURCE_INFO: Lazy<Mutex<String>> = Lazy::new(|| {
+static SOURCE_INFO: Lazy<Arc<String>> = Lazy::new(|| {
     let s = unsafe { osdp_sys::osdp_get_source_info() };
-    Mutex::new(cstr_to_string(s))
+    Arc::new(cstr_to_string(s))
 });
 
 /// Get LibOSDP version
 pub fn get_version() -> String {
-    VERSION.lock().clone()
+    VERSION.as_ref().clone()
 }
 
 /// Get LibOSDP source info string
 pub fn get_source_info() -> String {
-    SOURCE_INFO.lock().clone()
+    SOURCE_INFO.as_ref().clone()
 }
 
 /// PD ID information advertised by the PD.

--- a/rust/src/pd.rs
+++ b/rust/src/pd.rs
@@ -7,6 +7,9 @@
 //! happens on the PD itself (such as card read, key press, etc.,) snd sends it
 //! to the CP.
 
+#[cfg(feature = "std")]
+use crate::file::{impl_osdp_file_ops_for, OsdpFile, OsdpFileOps};
+use crate::{commands::OsdpCommand, events::OsdpEvent, osdp_sys, OsdpError, PdCapability, PdInfo};
 use alloc::vec::Vec;
 use core::ffi::c_void;
 use log::{debug, error, info, warn};
@@ -175,4 +178,5 @@ impl Drop for PeripheralDevice {
     }
 }
 
+#[cfg(feature = "std")]
 impl_osdp_file_ops_for!(PeripheralDevice);

--- a/rust/src/pd.rs
+++ b/rust/src/pd.rs
@@ -7,27 +7,19 @@
 //! happens on the PD itself (such as card read, key press, etc.,) snd sends it
 //! to the CP.
 
-use crate::{
-    commands::OsdpCommand,
-    PdInfo,
-    events::OsdpEvent,
-    file::{OsdpFile, OsdpFileOps, impl_osdp_file_ops_for},
-    osdp_sys,
-    OsdpError,
-    PdCapability,
-};
+use alloc::vec::Vec;
+use core::ffi::c_void;
 use log::{debug, error, info, warn};
-use std::ffi::c_void;
 
-type Result<T> = std::result::Result<T, OsdpError>;
+type Result<T> = core::result::Result<T, OsdpError>;
 type CommandCallback =
     unsafe extern "C" fn(data: *mut c_void, event: *mut osdp_sys::osdp_cmd) -> i32;
 
 unsafe extern "C" fn log_handler(
-    log_level: ::std::os::raw::c_int,
-    _file: *const ::std::os::raw::c_char,
-    _line: ::std::os::raw::c_ulong,
-    msg: *const ::std::os::raw::c_char,
+    log_level: ::core::ffi::c_int,
+    _file: *const ::core::ffi::c_char,
+    _line: ::core::ffi::c_ulong,
+    msg: *const ::core::ffi::c_char,
 ) {
     let msg = crate::cstr_to_string(msg);
     let msg = msg.trim();


### PR DESCRIPTION
The Rust crate currently depends heavily on `std`. Since OSDP is a protocol mostly for embedded devices I think `no_std` support is necessary.

This PR adds that support by:
- Using `core::*` and `alloc::*` types instead of `std::*` where possible.
- Defining a feature `"std"`, which users can opt out of. Things like `UnixChannel` or the `file` API will not be available then.
- Using [`parking_log`](https://crates.io/crates/parking_lot) and [`spin`](https://crates.io/crates/spin) as a replacement for `std::sync::Mutex`. I chose `parking_lot`, because it is widely used, cross platform and supports [`lock_api`](https://crates.io/crates/lock_api) and can therefore be used just like `spin::Mutex` for `no_std` without any changes. The use of `spin` should be temporary, because this is almost never what you really want. In the future we should probably let the user choose the concrete `Mutex` implementation that makes sense for their platform. I didn't do this, because I wanted to keep the changes backwards compatible for now.
- Defining custom `Read` and `Write` traits instead of `std::io::{Read, Write}`, because the latter is not `no_std` compatible. I couldn't just replace them with `embedded_io::{Read, Write}` either, because those are not object safe and can therefore not be used with `Box<dyn ...>`. My traits are just very thin wrappers around the others with blanket implementations for everything implementing `std::io::{Read, Write}` or `embedded_io::{Read, Write}`.

I am open for discussion about my decisions in this PR. :)