### PR TITLE
rust: Reduced number of dependencies

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,24 +9,23 @@ homepage = "https://libosdp.sidcha.dev/"
 readme = "README.md"
 repository = "https://github.com/goToMain/libosdp"
 license = "Apache-2.0"
-keywords = ["osdp", "libosdp", "acs", "sia", "weigand" ]
+keywords = ["osdp", "libosdp", "acs", "sia", "weigand"]
 categories = ["development-tools", "embedded"]
 
 [dependencies]
 bitflags = "2.4.0"
 embedded-io = "0.6.1"
-env_logger = "0.10.0"
-lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 libosdp-sys = "0.1.1"
 log = "0.4.20"
-multiqueue = "0.3.2"
 once_cell = "1.18.0"
-parking_lot = "0.12.1"
+parking_lot = { version = "0.12.1", optional = true }
 serde = { version = "1.0.192", features = ["derive"] }
-serde_with = "3.4.0"
 spin = "0.9.8"
-thiserror = "1.0.50"
+thiserror = { version = "1.0.50", optional = true }
+
+[dev-dependencies]
+env_logger = "0.10.0"
 
 [features]
 default = ["std"]
-std = []
+std = ["thiserror", "parking_lot"]

--- a/rust/src/channel/mod.rs
+++ b/rust/src/channel/mod.rs
@@ -13,26 +13,27 @@
 
 #[cfg(feature = "std")]
 pub mod unix_channel;
+use once_cell::sync::Lazy;
 #[cfg(feature = "std")]
 pub use unix_channel::UnixChannel;
 
-use lazy_static::lazy_static;
 #[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap as HashMap;
 use alloc::{boxed::Box, format, sync::Arc, vec};
 use core::ffi::c_void;
 #[cfg(feature = "std")]
-use std::{collections::{hash_map::DefaultHasher, HashMap}, hash::{Hash, Hasher}};
+use std::{
+    collections::{hash_map::DefaultHasher, HashMap},
+    hash::{Hash, Hasher},
+};
 
 #[cfg(feature = "std")]
 use parking_lot::Mutex;
 #[cfg(not(feature = "std"))]
 use spin::Mutex;
 
-lazy_static! {
-    static ref CHANNELS: Mutex<HashMap<i32, Arc<Mutex<Box<dyn Channel>>>>> =
-        Mutex::new(HashMap::new());
-}
+static CHANNELS: Lazy<Mutex<HashMap<i32, Arc<Mutex<Box<dyn Channel>>>>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
 
 impl alloc::fmt::Debug for OsdpChannel {
     fn fmt(&self, f: &mut alloc::fmt::Formatter<'_>) -> alloc::fmt::Result {
@@ -176,7 +177,9 @@ impl OsdpChannel {
     /// Create an instance of OsdpChannel for a given object that implements
     /// the Channel Trait.
     pub fn new<T: Channel>(stream: Box<dyn Channel>) -> OsdpChannel {
-        Self { stream: Arc::new(Mutex::new(stream)) }
+        Self {
+            stream: Arc::new(Mutex::new(stream)),
+        }
     }
 
     /// For internal use; in as_struct() of [`crate::PdInfo`]. This methods


### PR DESCRIPTION
Some of the dependencies weren't used and `lazy_static` could be replaced by `once_cell` which was used anyway.