### PR TITLE
Increasing the max data contained in an OSDP event to 128bytes

### DIFF
--- a/include/osdp.h
+++ b/include/osdp.h
@@ -17,7 +17,7 @@ extern "C" {
 #define OSDP_CMD_TEXT_MAX_LEN          32
 #define OSDP_CMD_KEYSET_KEY_MAX_LEN    32
 #define OSDP_CMD_MFG_MAX_DATALEN       64
-#define OSDP_EVENT_MAX_DATALEN         64
+#define OSDP_EVENT_MAX_DATALEN         128
 
 /**
  * @brief OSDP setup flags. See osdp_pd_info_t::flags


### PR DESCRIPTION
This is necessary because we are dealing with a Manufacturer Specific Response that contains at least 73 bytes of date.  The data is an ASN.1 serialized ECDSA P256 signature.  In the case of larger curves (e.g. P384) the signature will be longer but 128 bytes will handle it fine.  In the case of RSA signatures it is almost for sure that 128bytes will be too small but that is not a use case we are concerned with at the moment nor is it one we can test.