### PR TITLE
Fix regression in Rust binding. Commit 51b626c94bc39242f9793c916471bd…

### DIFF
--- a/rust/src/commands.rs
+++ b/rust/src/commands.rs
@@ -273,7 +273,7 @@ impl From<libosdp_sys::osdp_cmd_text> for OsdpCommandText {
 
 impl From<OsdpCommandText> for libosdp_sys::osdp_cmd_text {
     fn from(value: OsdpCommandText) -> Self {
-        let mut data: [u8; 32] = [0; 32];
+        let mut data = [0; libosdp_sys::OSDP_CMD_TEXT_MAX_LEN as usize];
         for i in 0..value.data.len() {
             data[i] = value.data[i];
         }
@@ -407,7 +407,7 @@ impl From<libosdp_sys::osdp_cmd_keyset> for OsdpCommandKeyset {
 
 impl From<OsdpCommandKeyset> for libosdp_sys::osdp_cmd_keyset {
     fn from(value: OsdpCommandKeyset) -> Self {
-        let mut data: [u8; 32] = [0; 32];
+        let mut data = [0; libosdp_sys::OSDP_CMD_KEYSET_KEY_MAX_LEN as usize];
         for i in 0..value.data.len() {
             data[i] = value.data[i];
         }
@@ -448,7 +448,7 @@ impl From<libosdp_sys::osdp_cmd_mfg> for OsdpCommandMfg {
 
 impl From<OsdpCommandMfg> for libosdp_sys::osdp_cmd_mfg {
     fn from(value: OsdpCommandMfg) -> Self {
-        let mut data: [u8; 64] = [0; 64];
+        let mut data = [0; libosdp_sys::OSDP_CMD_MFG_MAX_DATALEN as usize];
         for i in 0..value.data.len() {
             data[i] = value.data[i];
         }

--- a/rust/src/events.rs
+++ b/rust/src/events.rs
@@ -226,7 +226,7 @@ impl From<libosdp_sys::osdp_event_mfgrep> for OsdpEventMfgReply {
 
 impl From<OsdpEventMfgReply> for libosdp_sys::osdp_event_mfgrep {
     fn from(value: OsdpEventMfgReply) -> Self {
-        let mut data: [u8; 64] = [0; 64];
+        let mut data: [u8; 128] = [0; 128];
         for i in 0..value.data.len() {
             data[i] = value.data[i];
         }

--- a/rust/src/events.rs
+++ b/rust/src/events.rs
@@ -132,7 +132,7 @@ impl From<libosdp_sys::osdp_event_cardread> for OsdpEventCardRead {
 
 impl From<OsdpEventCardRead> for libosdp_sys::osdp_event_cardread {
     fn from(value: OsdpEventCardRead) -> Self {
-        let mut data: [u8; 64] = [0; 64];
+        let mut data = [0; libosdp_sys::OSDP_EVENT_CARDREAD_MAX_DATALEN as usize];
         let length = match value.format {
             OsdpCardFormats::Weigand => value.nr_bits as i32,
             _ => value.data.len() as i32,
@@ -185,7 +185,7 @@ impl From<libosdp_sys::osdp_event_keypress> for OsdpEventKeyPress {
 
 impl From<OsdpEventKeyPress> for libosdp_sys::osdp_event_keypress {
     fn from(value: OsdpEventKeyPress) -> Self {
-        let mut data: [u8; 64] = [0; 64];
+        let mut data = [0; libosdp_sys::OSDP_EVENT_KEYPRESS_MAX_DATALEN as usize];
         for i in 0..value.data.len() {
             data[i] = value.data[i];
         }
@@ -226,7 +226,7 @@ impl From<libosdp_sys::osdp_event_mfgrep> for OsdpEventMfgReply {
 
 impl From<OsdpEventMfgReply> for libosdp_sys::osdp_event_mfgrep {
     fn from(value: OsdpEventMfgReply) -> Self {
-        let mut data: [u8; 128] = [0; 128];
+        let mut data = [0; libosdp_sys::OSDP_EVENT_MFGREP_MAX_DATALEN as usize];
         for i in 0..value.data.len() {
             data[i] = value.data[i];
         }


### PR DESCRIPTION
…adafe24679 increased buffer size to 128 bytes. Adjust binding accordingly.