### PR TITLE
Continue normally on successful command callback on status commands

### DIFF
--- a/src/osdp_pd.c
+++ b/src/osdp_pd.c
@@ -305,7 +305,7 @@ static int pd_decode_command(struct osdp_pd *pd, uint8_t *buf, int len)
 		}
 		cmd.id = OSDP_CMD_STATUS;
 		cmd.status.type = OSDP_STATUS_REPORT_LOCAL;
-		if (do_command_callback(pd, &cmd)) {
+		if (!do_command_callback(pd, &cmd)) {
 			break;
 		}
 		event = (struct osdp_event *)pd->ephemeral_data;
@@ -324,7 +324,7 @@ static int pd_decode_command(struct osdp_pd *pd, uint8_t *buf, int len)
 		}
 		cmd.id = OSDP_CMD_STATUS;
 		cmd.status.type = OSDP_STATUS_REPORT_INPUT;
-		if (do_command_callback(pd, &cmd)) {
+		if (!do_command_callback(pd, &cmd)) {
 			break;
 		}
 		event = (struct osdp_event *)pd->ephemeral_data;
@@ -343,7 +343,7 @@ static int pd_decode_command(struct osdp_pd *pd, uint8_t *buf, int len)
 		}
 		cmd.id = OSDP_CMD_STATUS;
 		cmd.status.type = OSDP_STATUS_REPORT_OUTPUT;
-		if (do_command_callback(pd, &cmd)) {
+		if (!do_command_callback(pd, &cmd)) {
 			break;
 		}
 		event = (struct osdp_event *)pd->ephemeral_data;
@@ -358,7 +358,7 @@ static int pd_decode_command(struct osdp_pd *pd, uint8_t *buf, int len)
 		}
 		cmd.id = OSDP_CMD_STATUS;
 		cmd.status.type = OSDP_STATUS_REPORT_REMOTE;
-		if (do_command_callback(pd, &cmd)) {
+		if (!do_command_callback(pd, &cmd)) {
 			break;
 		}
 		event = (struct osdp_event *)pd->ephemeral_data;


### PR DESCRIPTION
Seems like this is just a typo to me, unless I do not understand. Not sure why we would want to "fail to decode" when the command callback returns successfully.

Was noticing this:
```
reading: ffffffff5300080006676ebc (this log is from SerialChannel)
OSDP: PD-0: [2024-04-12T22:55:12Z] [WARN ] vendor/src/osdp_phy.c:521: Packet scan skipped 3 bytes before SoM
command received (from command callback)
OSDP: PD-0: [2024-04-12T22:55:12Z] [ERROR] vendor/src/osdp_pd.c:661: Failed to decode command: CMD(67) Len:0 ret:-2
OSDP: PD-0: [2024-04-12T22:55:12Z] [DEBUG] vendor/src/osdp_pd.c:669: CMD: RSTAT(67) REPLY: NAK(41)
writing: ff5380090006410224fa (this log is from SerialChannel)
```
when using a basic command callback like this (in Python):
```
def handle_command(self, command):
        print('command received')
        return 0, None
```