### PR TITLE
pd: add OSDP_CMD_COMSET_DONE event in order to inform app to update his current baudrate

### DIFF
--- a/include/osdp.h
+++ b/include/osdp.h
@@ -691,16 +691,17 @@ struct osdp_cmd_file_tx {
  * @brief OSDP application exposed commands
  */
 enum osdp_cmd_e {
-	OSDP_CMD_OUTPUT = 1,  /**< Output control command */
-	OSDP_CMD_LED,         /**< Reader LED control command */
-	OSDP_CMD_BUZZER,      /**< Reader buzzer control command */
-	OSDP_CMD_TEXT,        /**< Reader text output command */
-	OSDP_CMD_KEYSET,      /**< Encryption Key Set Command */
-	OSDP_CMD_COMSET,      /**< PD communication configuration command */
-	OSDP_CMD_MFG,         /**< Manufacturer specific command */
-	OSDP_CMD_FILE_TX,     /**< File transfer command */
-	OSDP_CMD_STATUS,      /**< Status report command */
-	OSDP_CMD_SENTINEL     /**< Max command value */
+	OSDP_CMD_OUTPUT = 1, /**< Output control command */
+	OSDP_CMD_LED, /**< Reader LED control command */
+	OSDP_CMD_BUZZER, /**< Reader buzzer control command */
+	OSDP_CMD_TEXT, /**< Reader text output command */
+	OSDP_CMD_KEYSET, /**< Encryption Key Set Command */
+	OSDP_CMD_COMSET, /**< PD communication configuration command */
+	OSDP_CMD_COMSET_DONE, /**< end of PD communication configuration response, need to update baudrate */
+	OSDP_CMD_MFG, /**< Manufacturer specific command */
+	OSDP_CMD_FILE_TX, /**< File transfer command */
+	OSDP_CMD_STATUS, /**< Status report command */
+	OSDP_CMD_SENTINEL /**< Max command value */
 };
 
 /**

--- a/src/osdp_pd.c
+++ b/src/osdp_pd.c
@@ -1038,6 +1038,14 @@ static void osdp_pd_update(struct osdp_pd *pd)
 			CLEAR_FLAG(pd, PD_FLAG_SC_USE_SCBKD);
 			CLEAR_FLAG(pd, OSDP_FLAG_INSTALL_MODE);
 			sc_deactivate(pd);
+		} else if (pd->cmd_id == CMD_COMSET &&
+			   pd->reply_id == REPLY_COM) {
+			if (pd->command_callback) {
+				struct osdp_cmd cmd;
+				cmd.id = OSDP_CMD_COMSET_DONE;
+				pd->command_callback(pd->command_callback_arg,
+						     &cmd);
+			}
 		}
 	} else {
 		/**


### PR DESCRIPTION
This PR intends to add a callback for PD system in order to inform application that the COMSET reply has been sent, and therefore the baudrate can be update. See https://github.com/goToMain/libosdp/discussions/213.