### PR TITLE
Fix PlatformIO CP example

### DIFF
--- a/examples/platformio/cp.ino
+++ b/examples/platformio/cp.ino
@@ -47,8 +47,8 @@ osdp_pd_info_t pd_info[] = {
         .channel = {
             .data = nullptr,
             .id = 0,
-            .recv = serial1_send_func,
-            .send = serial1_recv_func,
+            .recv = serial1_recv_func,
+            .send = serial1_send_func,
             .flush = nullptr
         },
         .scbk = nullptr,


### PR DESCRIPTION
Functions were swapped, making the example fail with `[ERROR] Channel send for 10 bytes failed! ret: 0`.