### PR TITLE
MFG: remove command field on OSDP 2.2

### DIFF
--- a/include/osdp.h
+++ b/include/osdp.h
@@ -453,7 +453,7 @@ struct osdp_status_report {
 
 #define OSDP_CMD_TEXT_MAX_LEN          32
 #define OSDP_CMD_KEYSET_KEY_MAX_LEN    32
-#define OSDP_CMD_MFG_MAX_DATALEN       64
+#define OSDP_CMD_MFG_MAX_DATALEN       253 /* OSDP_PACKET_BUF_SIZE (256) - vendor code length (3) */
 
 /**
  * @brief Command sent from CP to Control digital output of PD.
@@ -670,17 +670,13 @@ struct osdp_cmd_mfg {
 	 */
 	uint32_t vendor_code;
 	/**
-	 * 1-byte manufacturer defined osdp command
-	 */
-	uint8_t command;
-	/**
-	 * length Length of command data (optional)
-	 */
-	uint8_t length;
-	/**
-	 * Command data (optional)
+	 * Command data
 	 */
 	uint8_t data[OSDP_CMD_MFG_MAX_DATALEN];
+	/**
+	 * Length of the data (internal use)
+	 */
+	uint8_t length;
 };
 
 /**
@@ -837,10 +833,6 @@ struct osdp_event_mfgrep {
 	 * 3-bytes IEEE assigned OUI of manufacturer
 	 */
 	uint32_t vendor_code;
-	/**
-	 * 1-byte reply code
-	 */
-	uint8_t command;
 	/**
 	 * Length of manufacturer data in bytes (optional)
 	 */

--- a/include/osdp.h
+++ b/include/osdp.h
@@ -453,7 +453,7 @@ struct osdp_status_report {
 
 #define OSDP_CMD_TEXT_MAX_LEN          32
 #define OSDP_CMD_KEYSET_KEY_MAX_LEN    32
-#define OSDP_CMD_MFG_MAX_DATALEN       253 /* OSDP_PACKET_BUF_SIZE (256) - vendor code length (3) */
+#define OSDP_CMD_MFG_MAX_DATALEN       64
 
 /**
  * @brief Command sent from CP to Control digital output of PD.

--- a/python/osdp_sys/data.c
+++ b/python/osdp_sys/data.c
@@ -298,8 +298,6 @@ static int pyosdp_make_dict_cmd_mfg(PyObject *obj, struct osdp_cmd *cmd)
 {
 	if (pyosdp_dict_add_int(obj, "vendor_code", cmd->mfg.vendor_code))
 		return -1;
-	if (pyosdp_dict_add_int(obj, "mfg_command", cmd->mfg.command))
-		return -1;
 	if (pyosdp_dict_add_bytes(obj, "data", cmd->mfg.data, cmd->mfg.length))
 		return -1;
 	return 0;
@@ -310,19 +308,15 @@ static int pyosdp_make_struct_cmd_mfg(struct osdp_cmd *p, PyObject *dict)
 	int i, data_length;
 	struct osdp_cmd_mfg *cmd = &p->mfg;
 	uint8_t *data_bytes;
-	int vendor_code, mfg_command;
+	int vendor_code;
 
 	if (pyosdp_dict_get_int(dict, "vendor_code", &vendor_code))
-		return -1;
-
-	if (pyosdp_dict_get_int(dict, "mfg_command", &mfg_command))
 		return -1;
 
 	if (pyosdp_dict_get_bytes(dict, "data", &data_bytes, &data_length))
 		return -1;
 
 	cmd->vendor_code = (uint32_t)vendor_code;
-	cmd->command = mfg_command;
 	cmd->length = data_length;
 	for (i = 0; i < cmd->length; i++)
 		cmd->data[i] = data_bytes[i];
@@ -488,8 +482,6 @@ static int pyosdp_make_dict_event_mfg_reply(PyObject *obj, struct osdp_event *ev
 {
 	if (pyosdp_dict_add_int(obj, "vendor_code", event->mfgrep.vendor_code))
 		return -1;
-	if (pyosdp_dict_add_int(obj, "mfg_command", event->mfgrep.command))
-		return -1;
 	if (pyosdp_dict_add_bytes(obj, "data", event->mfgrep.data, event->mfgrep.length))
 		return -1;
 	return 0;
@@ -505,14 +497,10 @@ static int pyosdp_make_struct_event_mfg_reply(struct osdp_event *p,
 	if (pyosdp_dict_get_int(dict, "vendor_code", &vendor_code))
 		return -1;
 
-	if (pyosdp_dict_get_int(dict, "mfg_command", &command))
-		return -1;
-
 	if (pyosdp_dict_get_bytes(dict, "data", &data_bytes, &data_length))
 		return -1;
 
 	ev->vendor_code = (uint32_t)vendor_code;
-	ev->command = (uint8_t)command;
 	ev->length = data_length;
 	for (i = 0; i < ev->length; i++)
 		ev->data[i] = data_bytes[i];

--- a/src/osdp_cp.c
+++ b/src/osdp_cp.c
@@ -300,7 +300,6 @@ static int cp_build_command(struct osdp_pd *pd, uint8_t *buf, int max_len)
 		buf[len++] = BYTE_0(cmd->mfg.vendor_code);
 		buf[len++] = BYTE_1(cmd->mfg.vendor_code);
 		buf[len++] = BYTE_2(cmd->mfg.vendor_code);
-		buf[len++] = cmd->mfg.command;
 		memcpy(buf + len, cmd->mfg.data, cmd->mfg.length);
 		len += cmd->mfg.length;
 		break;
@@ -631,7 +630,6 @@ static int cp_decode_response(struct osdp_pd *pd, uint8_t *buf, int len)
 		event.mfgrep.vendor_code = buf[pos++];
 		event.mfgrep.vendor_code |= buf[pos++] << 8;
 		event.mfgrep.vendor_code |= buf[pos++] << 16;
-		event.mfgrep.command = buf[pos++];
 		event.mfgrep.length = len - REPLY_MFGREP_LEN;
 		if (event.mfgrep.length > OSDP_EVENT_MFGREP_MAX_DATALEN) {
 			break;

--- a/src/osdp_cp.c
+++ b/src/osdp_cp.c
@@ -42,7 +42,7 @@
 #define REPLY_KEYPAD_DATA_LEN          2   /* variable length command */
 #define REPLY_RAW_DATA_LEN             4   /* variable length command */
 #define REPLY_BUSY_DATA_LEN            0
-#define REPLY_MFGREP_LEN               4   /* variable length command */
+#define REPLY_MFGREP_LEN               3   /* variable length command */
 
 enum osdp_cp_error_e {
 	OSDP_CP_ERR_NONE = 0,

--- a/src/osdp_pd.c
+++ b/src/osdp_pd.c
@@ -44,7 +44,7 @@
 #define REPLY_RMAC_I_LEN               17
 #define REPLY_KEYPAD_LEN               2
 #define REPLY_RAW_LEN                  4
-#define REPLY_MFGREP_LEN               3 /* variable length command */
+#define REPLY_MFGREP_LEN               4 /* variable length command */
 
 enum osdp_pd_error_e {
 	OSDP_PD_ERR_NONE = 0,

--- a/src/osdp_pd.c
+++ b/src/osdp_pd.c
@@ -30,7 +30,7 @@
 #define CMD_ABORT_DATA_LEN             0
 #define CMD_ACURXSIZE_DATA_LEN         2
 #define CMD_KEEPACTIVE_DATA_LEN        2
-#define CMD_MFG_DATA_LEN               4 /* variable length command */
+#define CMD_MFG_DATA_LEN               3 /* variable length command */
 
 #define REPLY_ACK_LEN                  1
 #define REPLY_PDID_LEN                 13
@@ -44,7 +44,7 @@
 #define REPLY_RMAC_I_LEN               17
 #define REPLY_KEYPAD_LEN               2
 #define REPLY_RAW_LEN                  4
-#define REPLY_MFGREP_LEN               4 /* variable length command */
+#define REPLY_MFGREP_LEN               3 /* variable length command */
 
 enum osdp_pd_error_e {
 	OSDP_PD_ERR_NONE = 0,
@@ -279,7 +279,6 @@ static void pd_stage_event_mfgrep(struct osdp_pd *pd, struct osdp_cmd_mfg *cmd)
 	ev.type = OSDP_EVENT_MFGREP;
 	ev.flags = 0;
 
-	ev.mfgrep.command = cmd->command;
 	ev.mfgrep.length = cmd->length;
 	ev.mfgrep.vendor_code = cmd->vendor_code;
 	memcpy(ev.mfgrep.data, cmd->data, cmd->length);
@@ -552,7 +551,6 @@ static int pd_decode_command(struct osdp_pd *pd, uint8_t *buf, int len)
 		cmd.mfg.vendor_code = buf[pos++]; /* vendor_code */
 		cmd.mfg.vendor_code |= buf[pos++] << 8;
 		cmd.mfg.vendor_code |= buf[pos++] << 16;
-		cmd.mfg.command = buf[pos++];
 		cmd.mfg.length = len - CMD_MFG_DATA_LEN;
 		if (cmd.mfg.length > OSDP_CMD_MFG_MAX_DATALEN) {
 			LOG_ERR("cmd length error");
@@ -874,7 +872,6 @@ static int pd_build_reply(struct osdp_pd *pd, uint8_t *buf, int max_len)
 		buf[len++] = BYTE_0(event->mfgrep.vendor_code);
 		buf[len++] = BYTE_1(event->mfgrep.vendor_code);
 		buf[len++] = BYTE_2(event->mfgrep.vendor_code);
-		buf[len++] = event->mfgrep.command;
 		memcpy(buf + len, event->mfgrep.data, event->mfgrep.length);
 		len += event->mfgrep.length;
 		ret = OSDP_PD_ERR_NONE;

--- a/tests/pytest/test_commands.py
+++ b/tests/pytest/test_commands.py
@@ -163,8 +163,7 @@ def test_command_mfg():
     test_cmd = {
         'command': Command.Manufacturer,
         'vendor_code': 0x00030201,
-        'mfg_command': 13,
-        'data': bytes([9,1,9,2,6,3,1,7,7,0])
+        'data': bytes([13,9,1,9,2,6,3,1,7,7,0])
     }
     assert cp.is_online(secure_pd_addr)
     assert cp.submit_command(secure_pd_addr, test_cmd)

--- a/tests/pytest/test_commands.py
+++ b/tests/pytest/test_commands.py
@@ -163,7 +163,7 @@ def test_command_mfg():
     test_cmd = {
         'command': Command.Manufacturer,
         'vendor_code': 0x00030201,
-        'data': bytes([13,9,1,9,2,6,3,1,7,7,0])
+        'data': bytes([9,1,9,2,6,3,1,7,7,0])
     }
     assert cp.is_online(secure_pd_addr)
     assert cp.submit_command(secure_pd_addr, test_cmd)
@@ -176,7 +176,6 @@ def test_command_mfg_with_reply():
         print(f"DEBUG: Received event: {event}")
         assert event['event'] == Event.ManufacturerReply
         assert event['vendor_code'] == 0x00030201
-        assert event['mfg_command'] == 13
         assert event['data'] == bytes([9,1,9,2,6,3,1,7,7,0])
         return 0
 
@@ -184,7 +183,6 @@ def test_command_mfg_with_reply():
         print(f"DEBUG: Received command: {command}")
         assert command['command'] == Command.Manufacturer
         assert command['vendor_code'] == 0x00030201
-        assert command['mfg_command'] == 13
         assert command['data'] == bytes([9,1,9,2,6,3,1,7,7,0])
         # Return positive value to trigger automatic manufacturer reply
         # The reply data is echoed back from the command data
@@ -204,17 +202,15 @@ def test_command_mfg_with_reply():
         test_cmd = {
             'command': Command.Manufacturer,
             'vendor_code': 0x00030201,
-            'mfg_command': 13,
             'data': bytes([9,1,9,2,6,3,1,7,7,0])
         }
 
         assert cp.submit_command(secure_pd_addr, test_cmd)
 
-        # The command should be received by the PD (with mfg_command field)
+        # The command should be received by the PD (without mfg_command field)
         expected_cmd_received = {
             'command': Command.Manufacturer,
             'vendor_code': 0x00030201,
-            'mfg_command': 13,
             'data': bytes([9,1,9,2,6,3,1,7,7,0])
         }
         assert_command_received(secure_pd, expected_cmd_received)
@@ -223,7 +219,6 @@ def test_command_mfg_with_reply():
         expected_event = {
             'event': Event.ManufacturerReply,
             'vendor_code': 0x00030201,
-            'mfg_command': 13,
             'data': bytes([9,1,9,2,6,3,1,7,7,0])
         }
         wait_for_non_notification_event(cp, secure_pd_addr, expected_event)

--- a/tests/pytest/test_events.py
+++ b/tests/pytest/test_events.py
@@ -69,8 +69,7 @@ def test_event_mfg_reply():
     event = {
         'event': Event.ManufacturerReply,
         'vendor_code': 0x153,
-        'mfg_command': 0x10,
-        'data': bytes([9,1,9,2,6,3,1,7,7,0]),
+        'data': bytes([0x10,9,1,9,2,6,3,1,7,7,0]),
     }
     secure_pd.submit_event(event)
     check_event(event)

--- a/tests/unit-tests/test-commands.c
+++ b/tests/unit-tests/test-commands.c
@@ -29,7 +29,6 @@ struct test_command_ctx {
 	/* Manufacturer command specific */
 	bool mfg_reply_expected;
 	uint32_t mfg_vendor_code;
-	uint8_t mfg_command;
 	uint8_t mfg_data[64];
 	int mfg_data_len;
 };
@@ -63,7 +62,6 @@ int test_commands_command_callback(void *arg, struct osdp_cmd *cmd)
 	if (cmd->id == OSDP_CMD_MFG) {
 		if (ctx->mfg_reply_expected &&
 		    cmd->mfg.vendor_code == ctx->mfg_vendor_code &&
-		    cmd->mfg.command == ctx->mfg_command &&
 		    cmd->mfg.length == ctx->mfg_data_len &&
 		    memcmp(cmd->mfg.data, ctx->mfg_data, ctx->mfg_data_len) == 0) {
 			/* Return positive value to trigger MFGREP */
@@ -296,7 +294,6 @@ static bool test_mfg_command_simple()
 		.id = OSDP_CMD_MFG,
 		.mfg = {
 			.vendor_code = 0x00030201,
-			.command = 13,
 			.length = 10,
 		},
 	};
@@ -319,7 +316,6 @@ static bool test_mfg_command_with_reply()
 	/* Set up expected manufacturer reply parameters */
 	g_test_ctx.mfg_reply_expected = true;
 	g_test_ctx.mfg_vendor_code = 0x00030201;
-	g_test_ctx.mfg_command = 13;
 	g_test_ctx.mfg_data_len = 10;
 	uint8_t test_data[] = {9,1,9,2,6,3,1,7,7,0};
 	memcpy(g_test_ctx.mfg_data, test_data, sizeof(test_data));
@@ -328,7 +324,6 @@ static bool test_mfg_command_with_reply()
 		.id = OSDP_CMD_MFG,
 		.mfg = {
 			.vendor_code = g_test_ctx.mfg_vendor_code,
-			.command = g_test_ctx.mfg_command,
 			.length = g_test_ctx.mfg_data_len,
 		},
 	};
@@ -355,7 +350,6 @@ static bool test_mfg_command_with_reply()
 	if (g_test_ctx.last_event_data) {
 		struct osdp_event *ev = (struct osdp_event *)g_test_ctx.last_event_data;
 		if (ev->mfgrep.vendor_code != g_test_ctx.mfg_vendor_code ||
-		    ev->mfgrep.command != g_test_ctx.mfg_command ||
 		    ev->mfgrep.length != g_test_ctx.mfg_data_len ||
 		    memcmp(ev->mfgrep.data, g_test_ctx.mfg_data, g_test_ctx.mfg_data_len) != 0) {
 			printf(SUB_2 "MFGREP event data mismatch\n");

--- a/tests/unit-tests/test-events.c
+++ b/tests/unit-tests/test-events.c
@@ -309,7 +309,6 @@ static bool test_mfgrep_event()
 		.type = OSDP_EVENT_MFGREP,
 		.mfgrep = {
 			.vendor_code = 0x00030201,
-			.command = 42,
 			.length = 8,
 		},
 	};
@@ -330,7 +329,6 @@ static bool test_mfgrep_event()
 	if (g_test_ctx.last_event_data) {
 		struct osdp_event *ev = (struct osdp_event *)g_test_ctx.last_event_data;
 		if (ev->mfgrep.vendor_code != event.mfgrep.vendor_code ||
-		    ev->mfgrep.command != event.mfgrep.command ||
 		    ev->mfgrep.length != event.mfgrep.length ||
 		    memcmp(ev->mfgrep.data, event.mfgrep.data, 8) != 0) {
 			printf(SUB_2 "MFGREP event data mismatch\n");


### PR DESCRIPTION
This PR fix the command MFG : the "command" field disapeared in OSDP 2.2 specification (only tested on PD devices).