### PR TITLE
Fix incorrect TRS data length

### DIFF
--- a/src/osdp_trs.c
+++ b/src/osdp_trs.c
@@ -192,8 +192,8 @@ int osdp_trs_reply_decode(struct osdp_pd *pd, uint8_t *buf, int len)
 	case REPLY_CARD_DATA:
 		reply->trs.card_data.reader = buf[pos++];
 		reply->trs.card_data.status = buf[pos++];
-		reply->trs.card_data.length = data_len;
-		memcpy(reply->trs.card_data.apdu, buf+pos, data_len);
+		reply->trs.card_data.length = data_len-2;
+		memcpy(reply->trs.card_data.apdu, buf+pos, data_len-2);
 		break;
 	case REPLY_PIN_ENTRY_COMPLETE:
 		reply->trs.pin_entry_complete.reader = buf[pos++];


### PR DESCRIPTION
When sending an APDU to a card, the reply's length is 2 bytes longer than it should be. The `.reader` and `.status` variables take the first 2 bytes of `data_len`, meaning the `memcpy` below reads 2 bytes past the end of the buffer.