### PR TITLE
fix Stat Decode error in file transfer keep alive mode

### DIFF
--- a/src/osdp_file.c
+++ b/src/osdp_file.c
@@ -129,7 +129,7 @@ int osdp_file_cmd_stat_decode(struct osdp_pd *pd, uint8_t *buf, int len)
 		return -1;
 	}
 
-	if (f->state != OSDP_FILE_INPROG) {
+	if (f->state != OSDP_FILE_INPROG && f->state != OSDP_FILE_KEEP_ALIVE) {
 		LOG_ERR("Stat_Decode: File transfer is not in progress!");
 		return -1;
 	}


### PR DESCRIPTION
Fix the bug when CP shows the error "Stat_Decode: File transfer is not in progress!" after file transfer and PD sends 3 in FtStatusDetail more then one time.