### PR TITLE
Clear out status memory when an LSTAT message comes in

### DIFF
--- a/src/osdp_pd.c
+++ b/src/osdp_pd.c
@@ -367,6 +367,7 @@ static int pd_decode_command(struct osdp_pd *pd, uint8_t *buf, int len)
 			break;
 		}
 		cmd.id = OSDP_CMD_STATUS;
+		memset(&cmd.status, 0, sizeof(cmd.status));
 		cmd.status.type = OSDP_STATUS_REPORT_LOCAL;
 		if (!do_command_callback(pd, &cmd)) {
 			ret = OSDP_PD_ERR_REPLY;


### PR DESCRIPTION
This is at least a partial fix for #271.  With this, the python code will no longer get a giant byte array for the `report` field when an LSTAT is requested:

```
OSDP: PD-0: 2025-12-22T22:50:09Z   osdp_pd.c:733  [DEBUG] CMD: LSTAT(64) REPLY: LSTATR(48)
PD: Received command: {'command': 9, 'type': 2, 'report': b''}
```

I'm not sure if the `report` field should be set in the first place, but least now it is a 0 byte length array.