### PR TITLE
allow REPLAY_OSTATR as reply for CMD_OUT

### DIFF
--- a/src/osdp_cp.c
+++ b/src/osdp_cp.c
@@ -1046,6 +1046,7 @@ static bool cp_check_online_response(struct osdp_pd *pd)
 	case CMD_LSTAT:        return pd->reply_id == REPLY_LSTATR;
 	case CMD_ISTAT:        return pd->reply_id == REPLY_ISTATR;
 	case CMD_OSTAT:        return pd->reply_id == REPLY_OSTATR;
+	case CMD_OUT:          return pd->reply_id == REPLY_OSTATR;
 	case CMD_RSTAT:        return pd->reply_id == REPLY_RSTATR;
 	default:
 		LOG_ERR("Unexpected respose: CMD: %s(%02x) REPLY: %s(%02x)",


### PR DESCRIPTION
According the specification `SIA OSDP v.2.2` a `osdp_OSTATR` is a valid reply to a `osdp_OUT` command.

See chapter 7.8:
```
7.8 Output Status Report (osdp_OSTATR)
Sent in response to an osdp_OSTAT command, an osdp_OUT command or as a "poll response"
```

