### PR TITLE
crypto: Zeroize security keys at function exit points

### DIFF
--- a/src/crypto/mbedtls.c
+++ b/src/crypto/mbedtls.c
@@ -9,6 +9,7 @@
 #include <assert.h>
 
 #include <mbedtls/aes.h>
+#include <mbedtls/platform_util.h>
 
 #ifdef MBEDTLS_PSA_CRYPTO_C
 #include <psa/crypto.h>
@@ -97,6 +98,11 @@ void osdp_fill_random(uint8_t *buf, int len)
 	int rc = mbedtls_ctr_drbg_random(&ctr_drbg_ctx, buf, len);
 	assert(rc == 0);
 #endif
+}
+
+void osdp_fill_zeros(void *buf, int len)
+{
+	mbedtls_platform_zeroize(buf, (size_t)len);
 }
 
 void osdp_crypt_teardown()

--- a/src/crypto/openssl.c
+++ b/src/crypto/openssl.c
@@ -107,6 +107,11 @@ void osdp_fill_random(uint8_t *buf, int len)
 	}
 }
 
+void osdp_fill_zeros(void *buf, int len)
+{
+	OPENSSL_cleanse(buf, (size_t)len);
+}
+
 void osdp_crypt_teardown()
 {
 }

--- a/src/crypto/tinyaes.c
+++ b/src/crypto/tinyaes.c
@@ -56,6 +56,15 @@ void osdp_fill_random(uint8_t *buf, int len)
 	}
 }
 
+void osdp_fill_zeros(void *buf, int len)
+{
+	volatile uint8_t *p = (volatile uint8_t *)buf;
+
+	while (len--) {
+		*p++ = 0;
+	}
+}
+
 void osdp_crypt_teardown()
 {
 }

--- a/src/osdp_common.h
+++ b/src/osdp_common.h
@@ -546,6 +546,7 @@ void osdp_crypt_setup();
 void osdp_encrypt(uint8_t *key, uint8_t *iv, uint8_t *data, int len);
 void osdp_decrypt(uint8_t *key, uint8_t *iv, uint8_t *data, int len);
 void osdp_fill_random(uint8_t *buf, int len);
+void osdp_fill_zeros(void *buf, int len);
 void osdp_crypt_teardown();
 
 /* --- from osdp_sc.c --- */

--- a/src/osdp_cp.c
+++ b/src/osdp_cp.c
@@ -1657,6 +1657,7 @@ void osdp_cp_teardown(osdp_t *ctx)
 		if (is_capture_enabled(pd)) {
 			osdp_packet_capture_finish(pd);
 		}
+		osdp_fill_zeros(&pd->sc, sizeof(struct osdp_secure_channel));
 
 #ifndef OPT_OSDP_STATIC
 		safe_free(pd->file);

--- a/src/osdp_pd.c
+++ b/src/osdp_pd.c
@@ -1263,6 +1263,7 @@ static void osdp_pd_update(struct osdp_pd *pd)
 		}
 		if (pd->cmd_id == CMD_KEYSET && pd->reply_id == REPLY_ACK) {
 			memcpy(pd->sc.scbk, pd->keyset_pending, 16);
+			osdp_fill_zeros(pd->keyset_pending, 16);
 			CLEAR_FLAG(pd, PD_FLAG_SC_USE_SCBKD);
 			CLEAR_FLAG(pd, PD_FLAG_INSTALL_MODE);
 			pd_sc_deactivate(pd);
@@ -1478,6 +1479,8 @@ void osdp_pd_teardown(osdp_t *ctx)
 	if (is_capture_enabled(pd)) {
 		osdp_packet_capture_finish(pd);
 	}
+
+	osdp_fill_zeros(&pd->sc, sizeof(struct osdp_secure_channel));
 
 	if (pd_ctx->channel.close) {
 		pd_ctx->channel.close(pd_ctx->channel.data);

--- a/src/osdp_sc.c
+++ b/src/osdp_sc.c
@@ -56,6 +56,7 @@ void osdp_compute_session_keys(struct osdp_pd *pd)
 	osdp_encrypt(scbk, NULL, pd->sc.s_enc, 16);
 	osdp_encrypt(scbk, NULL, pd->sc.s_mac1, 16);
 	osdp_encrypt(scbk, NULL, pd->sc.s_mac2, 16);
+	osdp_fill_zeros(scbk, sizeof(scbk));
 }
 
 void osdp_compute_cp_cryptogram(struct osdp_pd *pd)
@@ -93,10 +94,9 @@ int osdp_verify_cp_cryptogram(struct osdp_pd *pd)
 	memcpy(cp_crypto + 8, pd->sc.cp_random, 8);
 	osdp_encrypt(pd->sc.s_enc, NULL, cp_crypto, 16);
 
-	if (osdp_ct_compare(pd->sc.cp_cryptogram, cp_crypto, 16) != 0) {
-		return -1;
-	}
-	return 0;
+	int ret = osdp_ct_compare(pd->sc.cp_cryptogram, cp_crypto, 16) == 0 ? 0 : -1;
+	osdp_fill_zeros(cp_crypto, sizeof(cp_crypto));
+	return ret;
 }
 
 void osdp_compute_pd_cryptogram(struct osdp_pd *pd)
@@ -116,10 +116,9 @@ int osdp_verify_pd_cryptogram(struct osdp_pd *pd)
 	memcpy(pd_crypto + 8, pd->sc.pd_random, 8);
 	osdp_encrypt(pd->sc.s_enc, NULL, pd_crypto, 16);
 
-	if (osdp_ct_compare(pd->sc.pd_cryptogram, pd_crypto, 16) != 0) {
-		return -1;
-	}
-	return 0;
+	int ret = osdp_ct_compare(pd->sc.pd_cryptogram, pd_crypto, 16) == 0 ? 0 : -1;
+	osdp_fill_zeros(pd_crypto, sizeof(pd_crypto));
+	return ret;
 }
 
 void osdp_compute_rmac_i(struct osdp_pd *pd)


### PR DESCRIPTION
Per OWASP Secure Coding Practices [1]:

  "Overwrite any sensitive information stored in allocated memory
   at all exit points from the function."

Add osdp_fill_zeros() to each crypto backend (OPENSSL_cleanse, mbedtls_platform_zeroize, and a portable volatile-pointer loop for tinyaes since explicit_bzero() is a glibc/BSD extension not available on bare-metal toolchains like AVR libc), and use it to wipe SCBKs, keyset_pending, intermediate cryptograms, and the secure-channel state on PD/CP teardown.

[1] https://devguide.owasp.org/en/04-design/02-web-app-checklist/08-protect-data/

Fixes #296